### PR TITLE
feat(tasks): run arbitrary command with Austin tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,39 @@ This is equivalent of running `python main.py --verbose`:
 To Run the task, execute `Tasks: Run Task` from the Command Palette and select
 the task you specified in `tasks.json`.
 
+If you need to run a more generic command, for example by invoking a virtual
+environment manager like Poetry, you can use the `command` field, e.g.
+
+```json
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "type": "austin",
+            "label": "Profile tests",
+            "command": [
+                "poetry",
+                "run"
+            ],
+            "args": [
+                "python",
+                "-m",
+                "pytest",
+            ]
+        }
+    ]
+}
+```
+
+In the above task definition, the Austin command is placed in between the
+`command` and the `args` lists. That is, the above ends up running
+
+```console
+poetry run austin <austin args> python -m pytest
+```
+
+from the current working directory.
+
 ### Profiling a standalone script
 
 To profile a Python script, open it up in VS Code, open the command palette and

--- a/package.json
+++ b/package.json
@@ -122,9 +122,7 @@
     "taskDefinitions": [
       {
         "type": "austin",
-        "required": [
-          "file"
-        ],
+        "required": [],
         "properties": {
           "file": {
             "type": "string",
@@ -133,6 +131,10 @@
           "args": {
             "type": "array",
             "description": "Optional list of arguments to the task"
+          },
+          "command": {
+            "type": "array",
+            "description": "The command to run, together with its arguments, e.g. poetry."
           },
           "mode": {
             "description": "Profiling mode",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -113,33 +113,8 @@ export function activate(context: vscode.ExtensionContext) {
 		})
 	);
 
-	if (vscode.window.activeTextEditor?.document.languageId === "python") {
-		austinModeStatusBarItem.show();
-		austinIntervalStatusBarItem.show();
-	}
-
-	vscode.window.onDidChangeActiveTextEditor((event) => {
-		if (event?.document.languageId === "python") {
-			austinModeStatusBarItem.show();
-			austinIntervalStatusBarItem.show();
-		}
-		else {
-			austinModeStatusBarItem.hide();
-			austinIntervalStatusBarItem.hide();
-		}
-	});
-
-	context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(e => {
-		if (e.affectsConfiguration('austin.path')){
-			AustinRuntimeSettings.resetPath();
-		}
-		if (e.affectsConfiguration('austin.mode')){
-			AustinRuntimeSettings.resetMode();
-		}
-		if (e.affectsConfiguration('austin.interval')){
-			AustinRuntimeSettings.resetInterval();
-		}
-	}));
+	austinModeStatusBarItem.show();
+	austinIntervalStatusBarItem.show();
 }
 
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -7,14 +7,16 @@ export const DEFAULT_MODE = AustinMode.WallTime;
 
 export class AustinRuntimeSettings {
     private static config = vscode.workspace.getConfiguration('austin');
-    private static instance: AustinRuntimeSettings;
     // Keep me private
     private constructor() {
+        // Get the latest settings
+        AustinRuntimeSettings.config = vscode.workspace.getConfiguration('austin');
+
         let austinPath = AustinRuntimeSettings.config.get<string>("path", DEFAULT_PATH);
         if (austinPath === "") {
             austinPath = DEFAULT_PATH;
         }
-        const austinInterval: number = AustinRuntimeSettings.config.get<number>("interval",  DEFAULT_INTERVAL);
+        const austinInterval: number = AustinRuntimeSettings.config.get<number>("interval", DEFAULT_INTERVAL);
         const austinMode: AustinMode = AustinRuntimeSettings.config.get("mode", DEFAULT_MODE);
 
         this.settings = {
@@ -25,39 +27,25 @@ export class AustinRuntimeSettings {
     }
 
     public static get(): AustinRuntimeSettings {
-        if (!AustinRuntimeSettings.instance) {
-            AustinRuntimeSettings.instance = new AustinRuntimeSettings();
-        }
-
-        return AustinRuntimeSettings.instance;
+        return new AustinRuntimeSettings();
     }
 
     settings: AustinSettings;
 
-    public static getPath(): string { 
+    public static getPath(): string {
         return AustinRuntimeSettings.get().settings.path;
     }
 
-    public static setPath(newPath: string) { 
+    public static setPath(newPath: string) {
         AustinRuntimeSettings.config.update("path", newPath);
-        AustinRuntimeSettings.get().settings.path = newPath;
     }
 
-    public static resetPath() {
-        AustinRuntimeSettings.get().settings.path = AustinRuntimeSettings.config.get<string>("path", DEFAULT_PATH);
-    }
-
-    public static getInterval(): number { 
+    public static getInterval(): number {
         return AustinRuntimeSettings.get().settings.interval;
     }
 
-    public static setInterval(newInterval: number) { 
+    public static setInterval(newInterval: number) {
         AustinRuntimeSettings.config.update("interval", newInterval);
-        AustinRuntimeSettings.get().settings.interval = newInterval;
-    }
-
-    public static resetInterval() {
-        AustinRuntimeSettings.get().settings.interval = AustinRuntimeSettings.config.get<number>("interval",  DEFAULT_INTERVAL);
     }
 
     public static getMode(): AustinMode {
@@ -66,10 +54,6 @@ export class AustinRuntimeSettings {
 
     public static setMode(newMode: AustinMode) {
         AustinRuntimeSettings.config.update("mode", newMode);
-        AustinRuntimeSettings.get().settings.mode = newMode;
     }
 
-    public static resetMode() {
-        AustinRuntimeSettings.get().settings.mode = AustinRuntimeSettings.config.get("mode", DEFAULT_MODE);
-    }
 }

--- a/src/utils/commandFactory.ts
+++ b/src/utils/commandFactory.ts
@@ -9,26 +9,39 @@ export interface AustinCommandArguments {
 
 
 export function getAustinCommand(
-        pythonFile: string, 
-        pythonArgs: string[] | undefined = undefined, 
-        austinArgs: string[] | undefined = undefined,
-        interval: number | undefined = undefined,
-        mode: AustinMode | undefined = undefined
-        ) : AustinCommandArguments {
+    pythonFile: string | undefined = undefined,
+    command: string[] | undefined = undefined,
+    pythonArgs: string[] | undefined = undefined,
+    austinArgs: string[] | undefined = undefined,
+    interval: number | undefined = undefined,
+    mode: AustinMode | undefined = undefined
+): AustinCommandArguments {
     const settings = AustinRuntimeSettings.get().settings;
+    let _args: string[] = [];
+    let cmd = null;
+    if (command) {
+        cmd = command[0];
+        _args = _args.concat(command.slice(1));
+        _args.push(settings.path);
+    }
+    else {
+        cmd = settings.path;
+    }
     const _mode = mode ? mode : settings.mode;
     const _interval = interval ? interval : settings.interval;
     let sleepless = _mode === AustinMode.CpuTime ? "-s" : "";
-    let _args: string[] = [`-i ${_interval}`, `--pipe`, `${sleepless}`];
-    if (austinArgs)
-        {_args.concat(austinArgs);}
-    _args.push(getConfiguredInterpreter());
-    _args.push(pythonFile);
-    if (pythonArgs)
-        {_args.concat(pythonArgs);}
+    _args = _args.concat(["-i", `${_interval}`, `--pipe`, sleepless]);
+
+
+    if (austinArgs) { _args = _args.concat(austinArgs); }
+    if (pythonFile) {
+        _args.push(getConfiguredInterpreter());
+        _args.push(pythonFile);
+    }
+    if (pythonArgs) { _args = _args.concat(pythonArgs); }
 
     return {
-        cmd: `${settings.path}`,
+        cmd: cmd,
         args: _args
     };
 }


### PR DESCRIPTION
With this change, Austin tasks can execute any arbitrary command.
This is useful, e.g., when running with virtual environment
managers like poetry.