### PR TITLE
Only use Shift+F5 shortcut when not in debug mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
         "command": "austin-vscode.profile",
         "key": "shift+f5",
         "mac": "shift+f5",
-        "when": "editorLangId == python"
+        "when": "!inDebugMode && editorLangId == python"
       }
     ],
     "taskDefinitions": [


### PR DESCRIPTION
The Shift+F5 shortcut is already used to end debugging. When this extension is called, this shortcut will now both end debugging and start profiling.

This change prevents this by ignoring the "start profiling" keyboard shortcut when in debug mode.