### PR TITLE
feat: add support for MOJO v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [0.15.0]
+
+- Added support for MOJO version 3, used by Austin 3.6.
+
 ## [0.14.0]
 
 - Added setting option to select the type of line stats to display on the heat

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Austin VS Code",
   "publisher": "p403n1x87",
   "description": "Austin extension for VS Code",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "engines": {
     "vscode": "^1.57.0"
   },


### PR DESCRIPTION
We add support for the latest MOJO format. This allows binary data generated with Austin 3.6 to be displayed correctly in the UI.