### PR TITLE
feat: resolve task arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [0.17.0]
+
+- Added support for the `${file}` and `${workspaceFolder}` placeholders in the
+  Austin task definition.
+
 ## [0.16.0]
 
 - Added support for memory mode.


### PR DESCRIPTION
We allow the use of some placeholders in task arguments, such as `${file}` and `${workspaceFolder}`, to align with other task types that allow for a similar substitution.