### PR TITLE
fix: in-line memory percentages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Added support for the `${file}` and `${workspaceFolder}` placeholders in the
   Austin task definition.
 
+- Fixed a bug that caused in-line memory percentages to be larger than 100%.
+
 ## [0.16.0]
 
 - Added support for memory mode.

--- a/src/model.ts
+++ b/src/model.ts
@@ -267,7 +267,9 @@ export class AustinStats implements AustinStats {
     }
 
     public update(pid: number, tid: string, frames: FrameObject[], metric: number) {
-        this.overallTotal += metric;
+        if (metric > 0) {
+            this.overallTotal += metric;
+        }
 
         this.updateLineMap(frames, metric);
         this.updateTop(frames, metric);


### PR DESCRIPTION
Do not take deallocations into account when computing the overall total for memory profiles to avoid reporting percentages larger than 100%.