### PR TITLE
fix: cap bg opacity of hot lines for readability on dark themes

### DIFF
--- a/src/view.ts
+++ b/src/view.ts
@@ -46,7 +46,7 @@ function formatMemory(bytes: number) {
 function setLineHeat(frame: FrameObject, own: number, total: number, overallTotal: number, localTotal: number, mode: string) {
     const editor = vscode.window.activeTextEditor;
     if (editor !== undefined) {
-        const opacity = own / localTotal;
+        const opacity = Math.min(own / localTotal, 0.6);
         var color: string | undefined = undefined;
 
         switch (mode) {

--- a/src/view.ts
+++ b/src/view.ts
@@ -46,7 +46,7 @@ function formatMemory(bytes: number) {
 function setLineHeat(frame: FrameObject, own: number, total: number, overallTotal: number, localTotal: number, mode: string) {
     const editor = vscode.window.activeTextEditor;
     if (editor !== undefined) {
-        const opacity = Math.min(own / localTotal, 0.6);
+        const opacity = 0.6 * Math.sqrt(own / localTotal);
         var color: string | undefined = undefined;
 
         switch (mode) {


### PR DESCRIPTION
A suggested way to fix #56 