### PR TITLE
fix: ensure line end is at least line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [0.17.2]
+
+- Fixed the heat map visualisation when using the MOJO binary format with
+  Python versions earlier than 3.11.
+
 ## [0.17.1]
 
 - Fixed a visualisation bug that caused some frames to be aggregated incorrectly

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Austin VS Code",
   "publisher": "p403n1x87",
   "description": "Austin extension for VS Code",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "engines": {
     "vscode": "^1.57.0"
   },

--- a/src/view.ts
+++ b/src/view.ts
@@ -72,10 +72,11 @@ function setLineHeat(frame: FrameObject, own: number, total: number, overallTota
         if (!columnDelta) {
             editor.setDecorations(lineDecorator, [new vscode.Range(
                 editor.document.lineAt(frame.line - 1).range.start,
-                editor.document.lineAt((frame.lineEnd ? frame.lineEnd : frame.line) - 1).range.end
+                editor.document.lineAt((frame.lineEnd ? Math.max(frame.lineEnd, frame.line) : frame.line) - 1).range.end
             )]);
         }
         else {
+            // If we have column data we must have full line data too.
             let start = new vscode.Position(Math.max(frame.line - 1, 0), Math.max(frame.column! - 1, 0));
             let end = new vscode.Position(Math.max(frame.lineEnd! - 1, 0), Math.max(frame.columnEnd! - 1, 0));
             editor.setDecorations(lineDecorator, [new vscode.Range(start, end)]);
@@ -166,7 +167,7 @@ export function setLinesHeat(locations: Map<string, [FrameObject, number, number
 
         setLineHeat(fo, own, total, overallTotal, localTotal, mode);
 
-        for (let i = fo.line; i <= (fo.lineEnd ? fo.lineEnd : fo.line); i++) {
+        for (let i = fo.line; i <= (fo.lineEnd ? Math.max(fo.lineEnd, fo.line) : fo.line); i++) {
             if (lineStats.has(i)) {
                 let [ownSum, totalSum] = lineStats.get(i)!;
                 lineStats.set(i, [ownSum + own, totalSum + total]);


### PR DESCRIPTION
A bug in the MOJO generation for Python <= 3.11 from Austin caused the heat map to be wrongly visualised in the extension. That is due to Austin setting the line end to the first line of the function when it should be 0. We make sure that the line end is always at least line when trying to visualise heat maps and line stats in the editor to add support for the versions of Austin with the bug.