### PR TITLE
fix: regression for handling whitespaces in args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [0.17.3]
+
+- - Fixed regression for support for paths with spaces in Austin tasks.
+
 ## [0.17.2]
 
 - Fixed the heat map visualisation when using the MOJO binary format with

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Austin VS Code",
   "publisher": "p403n1x87",
   "description": "Austin extension for VS Code",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "engines": {
     "vscode": "^1.57.0"
   },

--- a/src/providers/executor.ts
+++ b/src/providers/executor.ts
@@ -8,6 +8,12 @@ import { clearDecorations, setLinesHeat } from "../view";
 
 import { DotenvPopulateInput, config } from "dotenv";
 
+
+function maybeEnquote(arg: string): string {
+  return arg.indexOf(' ') >= 0 ? `"${arg}"` : arg;
+}
+
+
 function resolveArgs(args: string[]): string[] {
   const resolvedArgs: string[] = [];
   args.forEach((arg) => {
@@ -83,8 +89,8 @@ export class AustinCommandExecutor implements vscode.Pseudoterminal {
       "cwd": this.cwd,
       "env": env,
     }); // NOSONAR
-    const args = resolvedArgs.join(' ');
-    this.writeEmitter.fire(`Running '${this.command.cmd}' with args '${args}'.\r\n`);
+    const args = resolvedArgs.map(maybeEnquote).join(' ');
+    this.writeEmitter.fire(`Running '${maybeEnquote(this.command.cmd)}' with args '${args}'.\r\n`);
     if (!this.fileName) {
       this.fileName = `${this.command.cmd} ${args}`;
     }

--- a/src/utils/commandFactory.ts
+++ b/src/utils/commandFactory.ts
@@ -3,10 +3,6 @@ import { AustinMode } from '../types';
 import { getConfiguredInterpreter } from './pythonExtension';
 
 
-function maybeEnquote(arg: string): string {
-    return arg.indexOf(' ') >= 0 ? `"${arg}"` : arg;
-}
-
 export interface AustinCommandArguments {
     cmd: string
     args: string[]
@@ -44,13 +40,13 @@ export function getAustinCommand(
     if (settings.binaryMode) { _args.push("-b"); }
     if (austinArgs) { _args = _args.concat(austinArgs); }
     if (pythonFile) {
-        _args.push(maybeEnquote(getConfiguredInterpreter()));
-        _args.push(maybeEnquote(pythonFile));
+        _args.push(getConfiguredInterpreter());
+        _args.push(pythonFile);
     }
-    if (pythonArgs) { _args = _args.concat(pythonArgs.map(maybeEnquote)); }
+    if (pythonArgs) { _args = _args.concat(pythonArgs); }
 
     return {
-        cmd: maybeEnquote(cmd),
+        cmd: cmd,
         args: _args,
         envFile: envFile
     };


### PR DESCRIPTION
We fix a regression for the handling of whitespaces in command arguments. According to the documentation for `spawn`, the arguments don't need to be enquoted beforehand, and doing so actually breaks the support for whitespaces.