### PR TITLE
feat: canvas flamegraph, UI polish, and build improvements

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,6 +1,8 @@
 .vscode/**
 .vscode-test/**
+node_modules/**
 out/test/**
+out/**/*.js.map
 src/**
 .gitignore
 .yarnrc

--- a/media/austin.css
+++ b/media/austin.css
@@ -43,15 +43,8 @@ button {
     display: inline-block;
 }
 
-.d3-flame-graph rect {
-    stroke-width: 1px;
-    stroke-opacity: 0.33;
-    fill-opacity: .9;
-}
-
-.d3-flame-graph-label {
-    margin-top: 4px;
-    color: antiquewhite;
+#chart canvas {
+    display: block;
 }
 
 #header {
@@ -114,6 +107,7 @@ button {
     backdrop-filter: blur(12px);
     background-color: rgba(46, 53, 58, 0.8);
     color: antiquewhite;
+    /* font-size set dynamically via JS to match editor font size */
     padding: 4px;
     position: fixed;
     bottom: 0px;

--- a/media/flamegraph-utils.js
+++ b/media/flamegraph-utils.js
@@ -1,0 +1,110 @@
+// @ts-check
+// Pure utility functions shared by flamegraph.js and the test suite.
+// UMD wrapper: works as a browser <script> (exposes window.FlamegraphUtils)
+// and as a Node.js require() (module.exports).
+(function (root, factory) {
+    if (typeof module === 'object' && module.exports) {
+        module.exports = factory();
+    } else {
+        // @ts-ignore
+        root.FlamegraphUtils = factory();
+    }
+// @ts-ignore
+}(typeof globalThis !== 'undefined' ? globalThis : this, function () {
+
+    /** @param {number} h @param {number} s @param {number} l */
+    function hslToHex(h, s, l) {
+        l /= 100;
+        const a = s * Math.min(l, 1 - l) / 100;
+        /** @param {number} n */
+        const f = n => {
+            const k = (n + h / 30) % 12;
+            const color = l - a * Math.max(Math.min(k - 3, 9 - k, 1), -1);
+            return Math.round(255 * color).toString(16).padStart(2, '0');
+        };
+        return `#${f(0)}${f(8)}${f(4)}`;
+    }
+
+    /** @param {string} text */
+    function hash(text) {
+        let h = 0;
+        for (let i = 0; i < text.length; i++) {
+            h = text.charCodeAt(i) + ((h << 5) - h);
+        }
+        return h;
+    }
+
+    /** @param {any} node */
+    function colorFor(node) {
+        if (!isNaN(+node.name)) { return '#808080'; }
+
+        const data = (node.data && typeof node.data === 'object') ? node.data : {};
+        const scope = data.name || node.name || '';
+        const module = data.file;
+
+        if (!module) { return hslToHex(0, 10, 70); }
+
+        const sat = hash(scope) % 20;
+        switch (scope.charAt(0)) {
+            case 'P': return hslToHex(120, sat, 70);
+            case 'T': return hslToHex(240, sat, 70);
+            default: {
+                const h = hash(module) % 360;
+                const s = hash(scope) % 10;
+                const isPy = module.endsWith('.py');
+                return hslToHex(h >= 0 ? h : -h, (isPy ? 60 : 20) + s, 60);
+            }
+        }
+    }
+
+    /** @param {string} text */
+    function esc(text) {
+        if (!text) { return ''; }
+        return String(text).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    }
+
+    /** @param {string} path */
+    function basename(path) {
+        return path ? path.replace(/\\/g, '/').split('/').pop() || path : '';
+    }
+
+    /** @param {any} obj */
+    function isEmpty(obj) {
+        return obj && Object.keys(obj).length === 0 && obj.constructor === Object;
+    }
+
+    /**
+     * Format a raw metric value into a human-readable string.
+     * For time modes: μs → ms → s → m.  For memory: B → KB → MB → GB.
+     * @param {number} v @param {string} mode
+     */
+    function formatValue(v, mode) {
+        if (mode === 'memory') {
+            if (v < 1024)        { return v.toFixed(0) + ' B'; }
+            if (v < 1024 * 1024) { return (v / 1024).toFixed(2) + ' KB'; }
+            if (v < 1024 ** 3)   { return (v / 1024 ** 2).toFixed(2) + ' MB'; }
+            return (v / 1024 ** 3).toFixed(2) + ' GB';
+        }
+        // cpu / wall — value is in microseconds
+        if (v < 1000) { return v.toFixed(0) + ' \u03BCs'; }
+        if (v < 1e6)  { return (v / 1000).toFixed(2) + ' ms'; }
+        if (v < 1e9)  { return (v / 1e6).toFixed(2) + ' s'; }
+        return (v / 1e9).toFixed(2) + ' m';
+    }
+
+    /**
+     * Build the footer HTML string for a hovered frame.
+     * @param {any} node @param {number} rootValue @param {string} mode
+     */
+    function footerText(node, rootValue, mode) {
+        const data = (node.data && typeof node.data === 'object') ? node.data : {};
+        const icon   = mode === 'memory' ? '\u{1F4E6}' : '\u23F1';
+        const pct    = (node.value / rootValue * 100).toFixed(2) + '%';
+        const metric = icon + '\uFE0E ' + formatValue(node.value, mode) + ' (' + pct + ')';
+        const scope  = esc(data.name || node.name || '');
+        const file   = data.file ? ' <span style="opacity:0.45">' + esc(data.file) + '</span>' : '';
+        return metric + ' &nbsp;\u00B7&nbsp; ' + scope + file;
+    }
+
+    return { hslToHex, hash, colorFor, esc, basename, isEmpty, formatValue, footerText };
+}));

--- a/media/flamegraph.js
+++ b/media/flamegraph.js
@@ -1,298 +1,482 @@
 // @ts-check
+(function () {
+    // @ts-ignore
+    const vscode = acquireVsCodeApi();
 
-// @ts-ignore
-const vscode = acquireVsCodeApi();
+    // ── Utilities (loaded from flamegraph-utils.js) ───────────────────────────
+    // @ts-ignore
+    const { colorFor, basename, isEmpty, footerText } = FlamegraphUtils;
 
-const d3 = /** @type {any} */ (window).d3;
-const flamegraph = /** @type {any} */ (window).flamegraph;
-
-/**
- * @param {number} h
- * @param {number} s
- * @param {number} l
- */
-function hslToHex(h, s, l) {
-    l /= 100;
-    const a = s * Math.min(l, 1 - l) / 100;
-    /** @param {number} n */
-    const f = n => {
-        const k = (n + h / 30) % 12;
-        const color = l - a * Math.max(Math.min(k - 3, 9 - k, 1), -1);
-        return Math.round(255 * color).toString(16).padStart(2, '0');   // convert to Hex and prefix "0" if needed
-    };
-    return `#${f(0)}${f(8)}${f(4)}`;
-}
-
-
-/** @param {string} text */
-var hash = function (text) {
-    var hash = 0;
-    for (var i = 0; i < text.length; i++) {
-        hash = text.charCodeAt(i) + ((hash << 5) - hash);
-    }
-    return hash;
-};
-
-/** @param {any} data */
-var stringToColour = function (data) {
-    let name = data.name;
-    let scope = data.data.name;
-    let module = data.data.file;
-
-    if (!module) {
-        return hslToHex(0, 10, 70);
-    }
-
-    if (!scope) {
-        scope = name;
-    }
-
-    var sat = hash(scope) % 20;
-    var hue;
-    switch (scope.charAt(0)) {
-        case 'P':
-            hue = 120;
-            break;
-        case 'T':
-            hue = 240;
-            break;
-        default:
-            let h = hash(module) % 360;
-            let s = hash(scope) % 10;
-            let isPy = module.endsWith(".py");
-            return hslToHex(h >= 0 ? h : -h, (isPy ? 60 : 20) + s, 60);
-    }
-
-    return hslToHex(hue, 0 + sat, 70);
-};
-
-/** @param {any} obj */
-function isEmpty(obj) {
-    return obj && Object.keys(obj).length === 0 && obj.constructor === Object;
-}
-
-/** @param {string} text */
-function esc(text) {
-    return text.replace("<", "&lt;").replace(">", "&gt;");
-}
-
-/**
- * @param {any} d
- * @param {any} parent
- */
-function timeLabel(d, parent) {
-    return (
-        esc(d.data.name) + " 🕘 " + d.data.value.toString() +
-        " μs (" + (d.data.value / parent.data.value * 100).toFixed(2) + "%)" +
-        (d.data.data.file ? " in " + d.data.data.file : "")
-    );
-}
-
-
-/**
- * @param {any} node
- * @param {string} parentKey
- */
-function addPathKeys(node, parentKey) {
-    var myKey = parentKey ? parentKey + '/' + node.name : node.name;
-    if (node.data) { node.data.pathKey = myKey; }
-    if (node.children) {
-        for (var i = 0; i < node.children.length; i++) {
-            addPathKeys(node.children[i], myKey);
-        }
-    }
-}
-
-
-/** @param {any} data */
-function flameGraph(data) {
-    if (!data || isEmpty(data)) {
-        return;
-    }
-
-    // Add path keys to every node's data before D3 processes it
-    if (data.children) {
-        for (var i = 0; i < data.children.length; i++) {
-            addPathKeys(data.children[i], '');
+    /** @param {any} node @param {string} parentKey */
+    function addPathKeys(node, parentKey) {
+        const myKey = parentKey ? parentKey + '/' + node.name : node.name;
+        if (node.data && typeof node.data === 'object') { node.data.pathKey = myKey; }
+        if (node.children) {
+            for (const child of node.children) { addPathKeys(child, myKey); }
         }
     }
 
-    var fg = flamegraph()
-        .width(/** @type {HTMLElement} */ (document.getElementById('chart')).clientWidth)
-        .transitionDuration(250)
-        .minFrameSize(0)
-        .transitionEase(d3.easeCubic)
-        .inverted(true)
-        .cellHeight(24)
-        .label(function (/** @type {any} */ d) {
-            var parent = d;
-            try {
-                while (parent.parent.parent) {
-                    parent = parent.parent;
+    // ── Constants ─────────────────────────────────────────────────────────────
+
+    let CELL_H = 24;            // row height in CSS px — updated before each rebuild
+    let FONT_SIZE = 13;         // editor font size in px — updated before each rebuild
+    let FONT_FAMILY = 'system-ui, sans-serif';
+    const LABEL_MIN_W = 30;     // minimum frame width (CSS px) to draw a text label
+    const DPR = window.devicePixelRatio || 1;
+
+    let currentMode = 'cpu';
+
+    // ── Layout engine ─────────────────────────────────────────────────────────
+
+    /**
+     * Walk from root toward target, collecting the ancestor chain
+     * (root inclusive, target exclusive).
+     * @param {any} root @param {any} target @returns {any[]}
+     */
+    function findAncestors(root, target) {
+        /** @type {any[]} */
+        const path = [];
+        /** @param {any} node @returns {boolean} */
+        function search(node) {
+            if (node === target) { return true; }
+            if (node.children) {
+                for (const child of node.children) {
+                    path.push(node);
+                    if (search(child)) { return true; }
+                    path.pop();
                 }
             }
-            catch (err) {
-                // parent.parent is undefined
+            return false;
+        }
+        search(root);
+        return path;
+    }
+
+    /**
+     * Partition the hierarchy into a flat array of frame descriptors.
+     * Ancestors of the zoom root are rendered at full width above it (dimmed).
+     * All coordinates are in CSS pixels; the canvas buffer is DPR× larger.
+     * @param {any} zoomRoot
+     * @param {number} cssWidth
+     * @param {any[]} ancestors  nodes above zoomRoot, root-first
+     */
+    function layoutFrames(zoomRoot, cssWidth, ancestors) {
+        /** @type {Array<{node:any,x:number,y:number,w:number,depth:number,color:string,highlighted:boolean,ancestor:boolean}>} */
+        const frames = [];
+        /** @type {Array<typeof frames>} */
+        const rowIndex = [];
+
+        // Ancestors: full-width, dimmed context rows
+        for (let i = 0; i < ancestors.length; i++) {
+            while (rowIndex.length <= i) { rowIndex.push([]); }
+            const frame = { node: ancestors[i], x: 0, y: i * CELL_H, w: cssWidth,
+                depth: i, color: colorFor(ancestors[i]), highlighted: false, ancestor: true };
+            frames.push(frame);
+            rowIndex[i].push(frame);
+        }
+
+        // Zoom root and its descendants
+        const offset = ancestors.length;
+        const queue = [{ node: zoomRoot, x: 0, depth: offset, w: cssWidth }];
+        while (queue.length) {
+            const { node, x, depth, w } = /** @type {any} */ (queue.shift());
+
+            while (rowIndex.length <= depth) { rowIndex.push([]); }
+            const frame = { node, x, y: depth * CELL_H, w, depth, color: colorFor(node), highlighted: false, ancestor: false };
+            frames.push(frame);
+            rowIndex[depth].push(frame);
+
+            if (!node.children || !node.children.length) { continue; }
+
+            const scale = w / node.value;
+            let childX = x;
+            for (const child of node.children) {
+                const childW = child.value * scale;
+                if (childW >= 1) {
+                    queue.push({ node: child, x: childX, depth: depth + 1, w: childW });
+                }
+                childX += childW;
             }
-            return timeLabel(d, parent);
-        });
-
-    fg.setWidth = function (/** @type {number} */ width) {
-        fg.width(width);
-        d3.select("#chart svg").style("width", width);
-        if (zoomedNode) {
-            fg.zoomTo(zoomedNode);
-        } else {
-            fg.resetZoom();
         }
-    };
 
-    fg.setColorMapper(function (/** @type {any} */ d) {
-        if (!isNaN(+d.data.name)) {
-            return '#808080';
-        }
-        return d.highlight ? "#F620F6" : stringToColour(d.data);
-    });
-
-    fg.setDetailsElement(document.getElementById("footer"));
-
-    fg.onClick(function (/** @type {any} */ d) {
-        zoomedNode = d;
-        vscode.postMessage(d.data.data);
-    });
-
-    fg.setSearchMatch(function (/** @type {any} */ d, /** @type {any} */ term) {
-        if (searchMode === 'path') {
-            return !!(d.data.data && d.data.data.pathKey === term);
-        }
-        return d.data.name.indexOf(term) !== -1 || (d.data.data.file && d.data.data.file.indexOf(term) !== -1);
-    });
-
-    d3.select("#chart")
-        .datum(data)
-        .call(fg);
-
-    window.addEventListener('resize', () => { fg.setWidth(/** @type {HTMLElement} */ (document.getElementById('chart')).clientWidth); });
-
-    fg.setWidth(/** @type {HTMLElement} */ (document.getElementById('chart')).clientWidth);
-
-    return fg;
-}
-
-
-/** @param {any} meta */
-function setMetadata(meta) {
-    if (!meta || isEmpty(meta)) {
-        return;
+        return { frames, rowIndex };
     }
 
-    const modeSpan = /** @type {HTMLElement} */ (document.getElementById("mode"));
-    const header = /** @type {HTMLElement} */ (document.getElementById("header"));
-    let mode;
-    switch (meta.mode) {
-        case "cpu":
-            mode = "CPU Time Profile";
-            document.body.style.backgroundColor = "rgba(127, 0, 0, .15)";
-            header.style.backgroundColor = "rgba(192, 64, 64, .8)";
-            break;
-        case "wall":
-            mode = "Wall Time Profile";
-            document.body.style.backgroundColor = "rgba(127, 127, 0, .15)";
-            header.style.backgroundColor = "rgba(192, 192, 64, .8)";
-            break;
-        case "memory":
-            mode = "Memory Allocations Profile";
-            document.body.style.backgroundColor = "rgba(0, 127, 0, .15)";
-            header.style.backgroundColor = "rgba(64, 192, 64, .8)";
-            break;
+    // ── Render engine ─────────────────────────────────────────────────────────
 
-        default:
-            mode = "[unsupported profile mode]";
+    /** @param {number} a @param {number} b @param {number} t */
+    function lerp(a, b, t) { return a + (b - a) * t; }
+
+    /** Ease-in-out quad. @param {number} t */
+    function easeInOut(t) { return t < 0.5 ? 2 * t * t : -1 + (4 - 2 * t) * t; }
+
+    /**
+     * @param {HTMLCanvasElement} canvas
+     * @param {CanvasRenderingContext2D} ctx
+     * @param {ReturnType<typeof layoutFrames>['frames']} frames
+     * @param {any} hoveredFrame
+     * @param {Map<any,{x:number,y:number,w:number}> | null} prevPos  for animation interpolation
+     * @param {number} t  interpolation factor 0→1
+     */
+    function render(canvas, ctx, frames, hoveredFrame, prevPos, t) {
+        const cssW = canvas.width / DPR;
+        const cssH = canvas.height / DPR;
+
+        ctx.setTransform(DPR, 0, 0, DPR, 0, 0);
+        ctx.clearRect(0, 0, cssW, cssH);
+
+        const primaryFont   = `${FONT_SIZE}px ${FONT_FAMILY}`;
+        const secondaryFont = `${Math.max(10, FONT_SIZE - 1)}px ${FONT_FAMILY}`;
+        ctx.textBaseline = 'middle';
+
+        for (const f of frames) {
+            const prev = prevPos && prevPos.get(f.node);
+            const x = prev ? lerp(prev.x, f.x, t) : f.x;
+            const y = prev ? lerp(prev.y, f.y, t) : f.y;
+            const w = prev ? lerp(prev.w, f.w, t) : f.w;
+
+            ctx.globalAlpha = f.ancestor ? 0.45 : 1;
+            ctx.fillStyle = f.color;
+            ctx.fillRect(x, y, w, CELL_H);
+
+            ctx.strokeStyle = 'rgba(0,0,0,0.18)';
+            ctx.lineWidth = 0.5;
+            ctx.strokeRect(x + 0.25, y + 0.25, w - 0.5, CELL_H - 0.5);
+
+            // Glow overlay for search-highlighted frames
+            if (f.highlighted) {
+                ctx.shadowColor = 'rgba(255,230,80,0.95)';
+                ctx.shadowBlur = 6;
+                ctx.strokeStyle = 'rgba(255,230,80,0.95)';
+                ctx.lineWidth = 1.5;
+                ctx.strokeRect(x + 0.75, y + 0.75, w - 1.5, CELL_H - 1.5);
+                ctx.shadowBlur = 0;
+            }
+
+            if (w >= LABEL_MIN_W) {
+                ctx.save();
+                ctx.beginPath();
+                ctx.rect(x + 2, y + 1, w - 4, CELL_H - 2);
+                ctx.clip();
+
+                const cy = y + CELL_H / 2;
+                const labelAlpha = f.ancestor ? 0.6 : 0.9;
+                const funcName = f.node.name || '';
+                const data = (f.node.data && typeof f.node.data === 'object') ? f.node.data : {};
+                const file = data.file ? basename(data.file) : '';
+
+                // Function name — prominent
+                ctx.font = primaryFont;
+                ctx.fillStyle = `rgba(255,255,255,${labelAlpha})`;
+                ctx.fillText(funcName, x + 4, cy);
+
+                // File name — dimmer, only if space remains
+                if (file) {
+                    const funcW = ctx.measureText(funcName).width;
+                    const fileX = x + 4 + funcW + 6;
+                    if (fileX + 20 < x + w - 2) {
+                        ctx.font = secondaryFont;
+                        ctx.fillStyle = `rgba(255,255,255,${labelAlpha * 0.55})`;
+                        ctx.fillText(file, fileX, cy);
+                    }
+                }
+
+                ctx.restore();
+            }
+
+            ctx.globalAlpha = 1;
+        }
+
+        if (hoveredFrame && t === 1) {
+            ctx.shadowColor = 'rgba(255,255,255,0.7)';
+            ctx.shadowBlur = 8;
+            ctx.strokeStyle = 'rgba(255,255,255,0.9)';
+            ctx.lineWidth = 1.5;
+            ctx.strokeRect(
+                hoveredFrame.x + 0.75, hoveredFrame.y + 0.75,
+                hoveredFrame.w - 1.5, CELL_H - 1.5
+            );
+            ctx.shadowBlur = 0;
+        }
     }
-    modeSpan.innerHTML = mode;
-}
 
+    // ── Hit testing ───────────────────────────────────────────────────────────
 
-var searchMode = 'text'; // 'text' | 'path'
-/** @type {any} */ var zoomedNode = null;
+    /**
+     * @param {ReturnType<typeof layoutFrames>['rowIndex']} rowIndex
+     * @param {number} cx  CSS px from canvas left
+     * @param {number} cy  CSS px from canvas top
+     */
+    function hitTest(rowIndex, cx, cy) {
+        const depth = Math.floor(cy / CELL_H);
+        const row = rowIndex[depth];
+        if (!row) { return null; }
+        for (const f of row) {
+            if (cx >= f.x && cx < f.x + f.w) { return f; }
+        }
+        return null;
+    }
 
-const state = vscode.getState();
-if (state) {
-    setMetadata(state.meta);
-    var graph = flameGraph(state.hierarchy);
-}
+    // ── Controller ────────────────────────────────────────────────────────────
 
+    /** @type {any} */ let rootNode = null;
+    /** @type {any} */ let zoomNode = null;
+    /** @type {ReturnType<typeof layoutFrames>['frames']} */ let frames = [];
+    /** @type {ReturnType<typeof layoutFrames>['rowIndex']} */ let rowIndex = [];
+    /** @type {any} */ let hoveredFrame = null;
+    let searchTerm = '';
+    let searchMode = 'text'; // 'text' | 'path'
+    let rafId = 0;
 
-window.addEventListener('message', event => {
-    if (event.data.focus) {
-        var focusKey = event.data.focus;
+    const ANIM_MS = 220;
+
+    const chartEl = /** @type {HTMLElement} */ (document.getElementById('chart'));
+    const footer  = document.getElementById('footer');
+
+    const canvas = document.createElement('canvas');
+    canvas.style.display = 'block';
+    chartEl.appendChild(canvas);
+    const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+    /**
+     * @param {boolean} animate  false on initial load (nothing to interpolate from)
+     */
+    function rebuildAndRender(animate) {
+        if (!rootNode) { return; }
+        const root = document.documentElement;
+        const rootStyle = getComputedStyle(root);
+        const bodyFs = parseFloat(getComputedStyle(document.body).fontSize) || 13;
+        FONT_SIZE   = bodyFs;
+        FONT_FAMILY = rootStyle.getPropertyValue('--vscode-font-family').trim() || 'system-ui, sans-serif';
+        CELL_H = Math.max(20, Math.ceil(FONT_SIZE * 1.8));
+        if (footer) { footer.style.fontSize = Math.round(FONT_SIZE * 0.95) + 'px'; }
+        const zoomRoot = zoomNode || rootNode;
+        const cssWidth = chartEl.clientWidth;
+
+        // Snapshot previous positions before recomputing layout
+        /** @type {Map<any,{x:number,y:number,w:number}>} */
+        const prevPos = new Map();
+        if (animate) {
+            for (const f of frames) { prevPos.set(f.node, { x: f.x, y: f.y, w: f.w }); }
+        }
+
+        canvas.style.width = cssWidth + 'px';
+        canvas.width = Math.round(cssWidth * DPR);
+
+        const ancestors = zoomNode ? findAncestors(rootNode, zoomNode) : [];
+        const layout = layoutFrames(zoomRoot, cssWidth, ancestors);
+        frames = layout.frames;
+        rowIndex = layout.rowIndex;
+
+        applySearch();
+
+        const cssHeight = rowIndex.length * CELL_H;
+        canvas.style.height = cssHeight + 'px';
+        canvas.height = Math.round(cssHeight * DPR);
+
+        // Cancel any in-progress animation
+        if (rafId) { cancelAnimationFrame(rafId); rafId = 0; }
+
+        if (!animate || prevPos.size === 0) {
+            render(canvas, ctx, frames, hoveredFrame, null, 1);
+            return;
+        }
+
+        let startTime = 0;
+        /** @param {number} ts */
+        function step(ts) {
+            if (!startTime) { startTime = ts; }
+            const t = easeInOut(Math.min(1, (ts - startTime) / ANIM_MS));
+            render(canvas, ctx, frames, null, prevPos, t);
+            rafId = t < 1 ? requestAnimationFrame(step) : 0;
+        }
+        rafId = requestAnimationFrame(step);
+    }
+
+    function applySearch() {
+        for (const f of frames) {
+            if (!searchTerm) { f.highlighted = false; continue; }
+            const data = (f.node.data && typeof f.node.data === 'object') ? f.node.data : {};
+            if (searchMode === 'path') {
+                f.highlighted = data.pathKey === searchTerm;
+            } else {
+                f.highlighted = (f.node.name || '').indexOf(searchTerm) !== -1 ||
+                    !!(data.file && data.file.indexOf(searchTerm) !== -1);
+            }
+        }
+    }
+
+    /** @param {any} hierarchy */
+    function loadData(hierarchy) {
+        if (!hierarchy || isEmpty(hierarchy)) { return; }
+        if (hierarchy.children) {
+            for (const child of hierarchy.children) { addPathKeys(child, ''); }
+        }
+        rootNode = hierarchy;
+        zoomNode = null;
+        hoveredFrame = null;
+        searchTerm = '';
+        rebuildAndRender(false);
+    }
+
+    /** @param {any} node */
+    function zoomTo(node) {
+        zoomNode = node;
+        hoveredFrame = null;
+        rebuildAndRender(true);
+    }
+
+    function resetZoom() {
+        zoomNode = null;
+        hoveredFrame = null;
+        rebuildAndRender(true);
+    }
+
+    /** @param {string} term @param {string} mode */
+    function setSearch(term, mode) {
+        searchTerm = term;
+        searchMode = mode || 'text';
+        applySearch();
+        render(canvas, ctx, frames, hoveredFrame, null, 1);
+    }
+
+    function clearSearch() {
+        searchTerm = '';
+        applySearch();
+        render(canvas, ctx, frames, hoveredFrame, null, 1);
+    }
+
+    /** @param {any} node @param {string} pathKey @returns {any} */
+    function findByPathKey(node, pathKey) {
+        if (node.data && typeof node.data === 'object' && node.data.pathKey === pathKey) {
+            return node;
+        }
+        if (node.children) {
+            for (const child of node.children) {
+                const found = findByPathKey(child, pathKey);
+                if (found) { return found; }
+            }
+        }
+        return null;
+    }
+
+    /** @param {string} pathKey */
+    function focusByPathKey(pathKey) {
+        if (!rootNode) { return; }
+        const target = findByPathKey(rootNode, pathKey);
+        // Set state in one shot to avoid double animation
+        zoomNode = target || null;
+        hoveredFrame = null;
+        searchTerm = pathKey;
         searchMode = 'path';
-        // Reset first so hidden/removed nodes are restored to the DOM before searching
-        graph.resetZoom();
-        graph.search(focusKey);
-        d3.select('#chart').selectAll('g').each(/** @this {Element} */ function (/** @type {any} */ d) {
-            if (d.data.data && d.data.data.pathKey === focusKey) {
-                zoomedNode = d;
-                graph.zoomTo(d);
-                // Scroll the frame to the centre of the visible area after the transition
-                var gEl = this;
-                setTimeout(function () {
-                    var rectEl = gEl.querySelector('rect');
-                    if (!rectEl) { return; }
-                    var headerEl = document.getElementById('header');
-                    var headerHeight = headerEl ? headerEl.offsetHeight : 0;
-                    var bounding = rectEl.getBoundingClientRect();
-                    var frameCenter = bounding.top + bounding.height / 2;
-                    var visibleCenter = headerHeight + (window.innerHeight - headerHeight) / 2;
-                    window.scrollBy({ top: frameCenter - visibleCenter, behavior: 'instant' });
-                }, 260);
-                return; // d3 each doesn't have break; first match is enough
-            }
-        });
-    } else if (event.data.search) {
-        searchMode = 'text';
-        graph.search(event.data.search);
+        rebuildAndRender(true);
+        if (target) {
+            setTimeout(() => canvas.scrollIntoView({ behavior: 'smooth', block: 'nearest' }), ANIM_MS + 30);
+        }
     }
-    else if (event.data.meta) {
-        setMetadata(event.data.meta);
-        graph = flameGraph(event.data.hierarchy);
 
-        vscode.setState(event.data);
-    }
-    else if (event.data === "reset") {
-        zoomedNode = null;
-        graph.resetZoom();
-        graph.clear();
-    }
-    else {
-        graph = flameGraph(event.data);
-        vscode.setState(event.data);
-    }
-});
+    // ── Events ────────────────────────────────────────────────────────────────
 
-document.addEventListener('keydown', (event) => {
-    vscode.postMessage({ "event": "keydown", "name": event.key });
-}, false);
-
-function onOpen() {
-    vscode.postMessage("open");
-}
-
-(function () {
-    var searchBox = /** @type {HTMLInputElement} */ (document.getElementById('search-box'));
-    if (!searchBox) { return; }
-    searchBox.addEventListener('input', function () {
-        if (!graph) { return; }
-        searchMode = 'text';
-        if (searchBox.value) {
-            graph.search(searchBox.value);
-        } else {
-            graph.clear();
+    canvas.addEventListener('click', e => {
+        const rect = canvas.getBoundingClientRect();
+        const f = hitTest(rowIndex, e.clientX - rect.left, e.clientY - rect.top);
+        if (!f) { return; }
+        zoomTo(f.node);
+        if (f.node.data && typeof f.node.data === 'object' && f.node.data.file) {
+            vscode.postMessage(f.node.data);
         }
     });
-    searchBox.addEventListener('keydown', function (e) {
-        e.stopPropagation(); // prevent the global keydown handler from firing
-    });
-})();
 
-vscode.postMessage("initialized");
+    canvas.addEventListener('mousemove', e => {
+        const rect = canvas.getBoundingClientRect();
+        const f = hitTest(rowIndex, e.clientX - rect.left, e.clientY - rect.top);
+        if (f === hoveredFrame) { return; }
+        hoveredFrame = f;
+        if (footer) { footer.innerHTML = f ? footerText(f.node, rootNode.value, currentMode) : ''; }
+        render(canvas, ctx, frames, hoveredFrame, null, 1);
+    });
+
+    canvas.addEventListener('mouseleave', () => {
+        hoveredFrame = null;
+        if (footer) { footer.innerHTML = ''; }
+        render(canvas, ctx, frames, null, null, 1);
+    });
+
+    new ResizeObserver(() => { if (rootNode) { rebuildAndRender(false); } }).observe(chartEl);
+
+    // ── Metadata ──────────────────────────────────────────────────────────────
+
+    /** @param {any} meta */
+    function setMetadata(meta) {
+        if (!meta || isEmpty(meta)) { return; }
+        currentMode = meta.mode || 'cpu';
+        const modeSpan = document.getElementById('mode');
+        const header   = document.getElementById('header');
+        let mode;
+        switch (meta.mode) {
+            case 'cpu':
+                mode = 'CPU Time Profile';
+                document.body.style.backgroundColor = 'rgba(127, 0, 0, .15)';
+                if (header) { header.style.backgroundColor = 'rgba(192, 64, 64, .8)'; }
+                break;
+            case 'wall':
+                mode = 'Wall Time Profile';
+                document.body.style.backgroundColor = 'rgba(127, 127, 0, .15)';
+                if (header) { header.style.backgroundColor = 'rgba(192, 192, 64, .8)'; }
+                break;
+            case 'memory':
+                mode = 'Memory Allocations Profile';
+                document.body.style.backgroundColor = 'rgba(0, 127, 0, .15)';
+                if (header) { header.style.backgroundColor = 'rgba(64, 192, 64, .8)'; }
+                break;
+            default:
+                mode = '[unsupported profile mode]';
+        }
+        if (modeSpan) { modeSpan.innerHTML = mode; }
+    }
+
+    // ── Messages ──────────────────────────────────────────────────────────────
+
+    window.addEventListener('message', event => {
+        const msg = event.data;
+        if (msg === 'reset') {
+            resetZoom();
+            clearSearch();
+        } else if (msg.focus) {
+            focusByPathKey(msg.focus);
+        } else if (msg.search) {
+            setSearch(msg.search, 'text');
+        } else if (msg.meta !== undefined) {
+            setMetadata(msg.meta);
+            loadData(msg.hierarchy);
+            vscode.setState(msg);
+        } else if (msg.hierarchy) {
+            loadData(msg.hierarchy);
+            vscode.setState(msg);
+        }
+    });
+
+    document.addEventListener('keydown', e => {
+        vscode.postMessage({ event: 'keydown', name: e.key });
+    });
+
+    const searchBox = /** @type {HTMLInputElement|null} */ (document.getElementById('search-box'));
+    if (searchBox) {
+        searchBox.addEventListener('input', () => {
+            searchBox.value ? setSearch(searchBox.value, 'text') : clearSearch();
+        });
+        searchBox.addEventListener('keydown', e => e.stopPropagation());
+    }
+
+    // Restore persisted state on webview reload
+    const state = vscode.getState();
+    if (state) {
+        setMetadata(state.meta);
+        loadData(state.hierarchy);
+    }
+
+    vscode.postMessage('initialized');
+
+    // Exposed globally for the Open button's onclick attribute
+    /** @type {any} */ (window).onOpen = function () { vscode.postMessage('open'); };
+})();

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,6 @@
       "version": "0.17.3",
       "license": "MIT",
       "dependencies": {
-        "d3": "^7.8.2",
-        "d3-flame-graph": "^4.0.6",
         "dotenv": "^16.3.1"
       },
       "devDependencies": {
@@ -1402,14 +1400,6 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
-    "node_modules/commander": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1436,429 +1426,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/d3": {
-      "version": "7.8.2",
-      "resolved": "https://registry.npmjs.org/d3/-/d3-7.8.2.tgz",
-      "integrity": "sha512-WXty7qOGSHb7HR7CfOzwN1Gw04MUOzN8qh9ZUsvwycIMb4DYMpY9xczZ6jUorGtO6bR9BPMPaueIKwiDxu9uiQ==",
-      "dependencies": {
-        "d3-array": "3",
-        "d3-axis": "3",
-        "d3-brush": "3",
-        "d3-chord": "3",
-        "d3-color": "3",
-        "d3-contour": "4",
-        "d3-delaunay": "6",
-        "d3-dispatch": "3",
-        "d3-drag": "3",
-        "d3-dsv": "3",
-        "d3-ease": "3",
-        "d3-fetch": "3",
-        "d3-force": "3",
-        "d3-format": "3",
-        "d3-geo": "3",
-        "d3-hierarchy": "3",
-        "d3-interpolate": "3",
-        "d3-path": "3",
-        "d3-polygon": "3",
-        "d3-quadtree": "3",
-        "d3-random": "3",
-        "d3-scale": "4",
-        "d3-scale-chromatic": "3",
-        "d3-selection": "3",
-        "d3-shape": "3",
-        "d3-time": "3",
-        "d3-time-format": "4",
-        "d3-timer": "3",
-        "d3-transition": "3",
-        "d3-zoom": "3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-array": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
-      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
-      "dependencies": {
-        "internmap": "^1.0.0"
-      }
-    },
-    "node_modules/d3-axis": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
-      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-brush": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
-      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
-      "dependencies": {
-        "d3-dispatch": "1 - 3",
-        "d3-drag": "2 - 3",
-        "d3-interpolate": "1 - 3",
-        "d3-selection": "3",
-        "d3-transition": "3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-chord": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
-      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
-      "dependencies": {
-        "d3-path": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-color": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
-      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-contour": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
-      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
-      "dependencies": {
-        "d3-array": "^3.2.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-contour/node_modules/d3-array": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.2.tgz",
-      "integrity": "sha512-yEEyEAbDrF8C6Ob2myOBLjwBLck1Z89jMGFee0oPsn95GqjerpaOA4ch+vc2l0FNFFwMD5N7OCSEN5eAlsUbgQ==",
-      "dependencies": {
-        "internmap": "1 - 2"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-delaunay": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.2.tgz",
-      "integrity": "sha512-IMLNldruDQScrcfT+MWnazhHbDJhcRJyOEBAJfwQnHle1RPh6WDuLvxNArUju2VSMSUuKlY5BGHRJ2cYyoFLQQ==",
-      "dependencies": {
-        "delaunator": "5"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-dispatch": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
-      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-drag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
-      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
-      "dependencies": {
-        "d3-dispatch": "1 - 3",
-        "d3-selection": "3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-dsv": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
-      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
-      "dependencies": {
-        "commander": "7",
-        "iconv-lite": "0.6",
-        "rw": "1"
-      },
-      "bin": {
-        "csv2json": "bin/dsv2json.js",
-        "csv2tsv": "bin/dsv2dsv.js",
-        "dsv2dsv": "bin/dsv2dsv.js",
-        "dsv2json": "bin/dsv2json.js",
-        "json2csv": "bin/json2dsv.js",
-        "json2dsv": "bin/json2dsv.js",
-        "json2tsv": "bin/json2dsv.js",
-        "tsv2csv": "bin/dsv2dsv.js",
-        "tsv2json": "bin/dsv2json.js"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-ease": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
-      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-fetch": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
-      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
-      "dependencies": {
-        "d3-dsv": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-flame-graph": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/d3-flame-graph/-/d3-flame-graph-4.1.3.tgz",
-      "integrity": "sha512-NijuhJZhaTMwobVgwGQ67x9PovqMMHXBbs0FMHEGJvsWZGuL4M7OsB03v8mHdyVyHhnQYGsYnb5w021e9+R+RQ==",
-      "dependencies": {
-        "d3-array": "^3.1.1",
-        "d3-dispatch": "^3.0.1",
-        "d3-ease": "^3.0.1",
-        "d3-format": "^3.0.1",
-        "d3-hierarchy": "^3.0.1",
-        "d3-scale": "^4.0.2",
-        "d3-selection": "^3.0.0",
-        "d3-transition": "^3.0.1"
-      }
-    },
-    "node_modules/d3-flame-graph/node_modules/d3-array": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.1.6.tgz",
-      "integrity": "sha512-DCbBBNuKOeiR9h04ySRBMW52TFVc91O9wJziuyXw6Ztmy8D3oZbmCkOO3UHKC7ceNJsN2Mavo9+vwV8EAEUXzA==",
-      "dependencies": {
-        "internmap": "1 - 2"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-force": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
-      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
-      "dependencies": {
-        "d3-dispatch": "1 - 3",
-        "d3-quadtree": "1 - 3",
-        "d3-timer": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-format": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
-      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-geo": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.0.tgz",
-      "integrity": "sha512-JEo5HxXDdDYXCaWdwLRt79y7giK8SbhZJbFWXqbRTolCHFI5jRqteLzCsq51NKbUoX0PjBVSohxrx+NoOUujYA==",
-      "dependencies": {
-        "d3-array": "2.5.0 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-hierarchy": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
-      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-interpolate": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
-      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
-      "dependencies": {
-        "d3-color": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-path": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
-      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-polygon": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
-      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-quadtree": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
-      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-random": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
-      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-scale": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
-      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
-      "dependencies": {
-        "d3-array": "2.10.0 - 3",
-        "d3-format": "1 - 3",
-        "d3-interpolate": "1.2.0 - 3",
-        "d3-time": "2.1.1 - 3",
-        "d3-time-format": "2 - 4"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-scale-chromatic": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.0.0.tgz",
-      "integrity": "sha512-Lx9thtxAKrO2Pq6OO2Ua474opeziKr279P/TKZsMAhYyNDD3EnCffdbgeSYN5O7m2ByQsxtuP2CSDczNUIZ22g==",
-      "dependencies": {
-        "d3-color": "1 - 3",
-        "d3-interpolate": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-selection": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
-      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-shape": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
-      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
-      "dependencies": {
-        "d3-path": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-time": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.1.1.tgz",
-      "integrity": "sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==",
-      "dependencies": {
-        "d3-array": "2"
-      }
-    },
-    "node_modules/d3-time-format": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
-      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
-      "dependencies": {
-        "d3-time": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-timer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
-      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-transition": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
-      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
-      "dependencies": {
-        "d3-color": "1 - 3",
-        "d3-dispatch": "1 - 3",
-        "d3-ease": "1 - 3",
-        "d3-interpolate": "1 - 3",
-        "d3-timer": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "d3-selection": "2 - 3"
-      }
-    },
-    "node_modules/d3-zoom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
-      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
-      "dependencies": {
-        "d3-dispatch": "1 - 3",
-        "d3-drag": "2 - 3",
-        "d3-interpolate": "1 - 3",
-        "d3-selection": "2 - 3",
-        "d3-transition": "2 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3/node_modules/d3-array": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.2.tgz",
-      "integrity": "sha512-yEEyEAbDrF8C6Ob2myOBLjwBLck1Z89jMGFee0oPsn95GqjerpaOA4ch+vc2l0FNFFwMD5N7OCSEN5eAlsUbgQ==",
-      "dependencies": {
-        "internmap": "1 - 2"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3/node_modules/d3-time": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
-      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
-      "dependencies": {
-        "d3-array": "2 - 3"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/debug": {
@@ -1897,14 +1464,6 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/delaunator": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.0.tgz",
-      "integrity": "sha512-AyLvtyJdbv/U1GkiS6gUUzclRoAY4Gs75qkMygJJhU75LW4DNuSF2RMzpxs9jw9Oz1BobHjTdkG3zdP55VxAqw==",
-      "dependencies": {
-        "robust-predicates": "^3.0.0"
-      }
     },
     "node_modules/diff": {
       "version": "7.0.0",
@@ -2455,17 +2014,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -2529,11 +2077,6 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
-    },
-    "node_modules/internmap": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
-      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -3279,16 +2822,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/robust-predicates": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.1.tgz",
-      "integrity": "sha512-ndEIpszUHiG4HtDsQLeIuMvRsDnn8c8rYStabochtUeCvfuvNptb5TUbVD68LRAILPX7p9nqQGh4xJgn3EHS/g=="
-    },
-    "node_modules/rw": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
-      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="
-    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -3309,11 +2842,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/semver": {
       "version": "7.7.4",
@@ -4473,11 +4001,6 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
-    "commander": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="
-    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -4501,322 +4024,6 @@
         "which": "^2.0.1"
       }
     },
-    "d3": {
-      "version": "7.8.2",
-      "resolved": "https://registry.npmjs.org/d3/-/d3-7.8.2.tgz",
-      "integrity": "sha512-WXty7qOGSHb7HR7CfOzwN1Gw04MUOzN8qh9ZUsvwycIMb4DYMpY9xczZ6jUorGtO6bR9BPMPaueIKwiDxu9uiQ==",
-      "requires": {
-        "d3-array": "3",
-        "d3-axis": "3",
-        "d3-brush": "3",
-        "d3-chord": "3",
-        "d3-color": "3",
-        "d3-contour": "4",
-        "d3-delaunay": "6",
-        "d3-dispatch": "3",
-        "d3-drag": "3",
-        "d3-dsv": "3",
-        "d3-ease": "3",
-        "d3-fetch": "3",
-        "d3-force": "3",
-        "d3-format": "3",
-        "d3-geo": "3",
-        "d3-hierarchy": "3",
-        "d3-interpolate": "3",
-        "d3-path": "3",
-        "d3-polygon": "3",
-        "d3-quadtree": "3",
-        "d3-random": "3",
-        "d3-scale": "4",
-        "d3-scale-chromatic": "3",
-        "d3-selection": "3",
-        "d3-shape": "3",
-        "d3-time": "3",
-        "d3-time-format": "4",
-        "d3-timer": "3",
-        "d3-transition": "3",
-        "d3-zoom": "3"
-      },
-      "dependencies": {
-        "d3-array": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.2.tgz",
-          "integrity": "sha512-yEEyEAbDrF8C6Ob2myOBLjwBLck1Z89jMGFee0oPsn95GqjerpaOA4ch+vc2l0FNFFwMD5N7OCSEN5eAlsUbgQ==",
-          "requires": {
-            "internmap": "1 - 2"
-          }
-        },
-        "d3-time": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
-          "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
-          "requires": {
-            "d3-array": "2 - 3"
-          }
-        }
-      }
-    },
-    "d3-array": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
-      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
-      "requires": {
-        "internmap": "^1.0.0"
-      }
-    },
-    "d3-axis": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
-      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw=="
-    },
-    "d3-brush": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
-      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
-      "requires": {
-        "d3-dispatch": "1 - 3",
-        "d3-drag": "2 - 3",
-        "d3-interpolate": "1 - 3",
-        "d3-selection": "3",
-        "d3-transition": "3"
-      }
-    },
-    "d3-chord": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
-      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
-      "requires": {
-        "d3-path": "1 - 3"
-      }
-    },
-    "d3-color": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
-      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="
-    },
-    "d3-contour": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
-      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
-      "requires": {
-        "d3-array": "^3.2.0"
-      },
-      "dependencies": {
-        "d3-array": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.2.tgz",
-          "integrity": "sha512-yEEyEAbDrF8C6Ob2myOBLjwBLck1Z89jMGFee0oPsn95GqjerpaOA4ch+vc2l0FNFFwMD5N7OCSEN5eAlsUbgQ==",
-          "requires": {
-            "internmap": "1 - 2"
-          }
-        }
-      }
-    },
-    "d3-delaunay": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.2.tgz",
-      "integrity": "sha512-IMLNldruDQScrcfT+MWnazhHbDJhcRJyOEBAJfwQnHle1RPh6WDuLvxNArUju2VSMSUuKlY5BGHRJ2cYyoFLQQ==",
-      "requires": {
-        "delaunator": "5"
-      }
-    },
-    "d3-dispatch": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
-      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg=="
-    },
-    "d3-drag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
-      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
-      "requires": {
-        "d3-dispatch": "1 - 3",
-        "d3-selection": "3"
-      }
-    },
-    "d3-dsv": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
-      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
-      "requires": {
-        "commander": "7",
-        "iconv-lite": "0.6",
-        "rw": "1"
-      }
-    },
-    "d3-ease": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
-      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="
-    },
-    "d3-fetch": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
-      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
-      "requires": {
-        "d3-dsv": "1 - 3"
-      }
-    },
-    "d3-flame-graph": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/d3-flame-graph/-/d3-flame-graph-4.1.3.tgz",
-      "integrity": "sha512-NijuhJZhaTMwobVgwGQ67x9PovqMMHXBbs0FMHEGJvsWZGuL4M7OsB03v8mHdyVyHhnQYGsYnb5w021e9+R+RQ==",
-      "requires": {
-        "d3-array": "^3.1.1",
-        "d3-dispatch": "^3.0.1",
-        "d3-ease": "^3.0.1",
-        "d3-format": "^3.0.1",
-        "d3-hierarchy": "^3.0.1",
-        "d3-scale": "^4.0.2",
-        "d3-selection": "^3.0.0",
-        "d3-transition": "^3.0.1"
-      },
-      "dependencies": {
-        "d3-array": {
-          "version": "3.1.6",
-          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.1.6.tgz",
-          "integrity": "sha512-DCbBBNuKOeiR9h04ySRBMW52TFVc91O9wJziuyXw6Ztmy8D3oZbmCkOO3UHKC7ceNJsN2Mavo9+vwV8EAEUXzA==",
-          "requires": {
-            "internmap": "1 - 2"
-          }
-        }
-      }
-    },
-    "d3-force": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
-      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
-      "requires": {
-        "d3-dispatch": "1 - 3",
-        "d3-quadtree": "1 - 3",
-        "d3-timer": "1 - 3"
-      }
-    },
-    "d3-format": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
-      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA=="
-    },
-    "d3-geo": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.0.tgz",
-      "integrity": "sha512-JEo5HxXDdDYXCaWdwLRt79y7giK8SbhZJbFWXqbRTolCHFI5jRqteLzCsq51NKbUoX0PjBVSohxrx+NoOUujYA==",
-      "requires": {
-        "d3-array": "2.5.0 - 3"
-      }
-    },
-    "d3-hierarchy": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
-      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA=="
-    },
-    "d3-interpolate": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
-      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
-      "requires": {
-        "d3-color": "1 - 3"
-      }
-    },
-    "d3-path": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
-      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="
-    },
-    "d3-polygon": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
-      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg=="
-    },
-    "d3-quadtree": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
-      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw=="
-    },
-    "d3-random": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
-      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ=="
-    },
-    "d3-scale": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
-      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
-      "requires": {
-        "d3-array": "2.10.0 - 3",
-        "d3-format": "1 - 3",
-        "d3-interpolate": "1.2.0 - 3",
-        "d3-time": "2.1.1 - 3",
-        "d3-time-format": "2 - 4"
-      }
-    },
-    "d3-scale-chromatic": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.0.0.tgz",
-      "integrity": "sha512-Lx9thtxAKrO2Pq6OO2Ua474opeziKr279P/TKZsMAhYyNDD3EnCffdbgeSYN5O7m2ByQsxtuP2CSDczNUIZ22g==",
-      "requires": {
-        "d3-color": "1 - 3",
-        "d3-interpolate": "1 - 3"
-      }
-    },
-    "d3-selection": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
-      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="
-    },
-    "d3-shape": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
-      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
-      "requires": {
-        "d3-path": "^3.1.0"
-      }
-    },
-    "d3-time": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.1.1.tgz",
-      "integrity": "sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==",
-      "requires": {
-        "d3-array": "2"
-      }
-    },
-    "d3-time-format": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
-      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
-      "requires": {
-        "d3-time": "1 - 3"
-      }
-    },
-    "d3-timer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
-      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="
-    },
-    "d3-transition": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
-      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
-      "requires": {
-        "d3-color": "1 - 3",
-        "d3-dispatch": "1 - 3",
-        "d3-ease": "1 - 3",
-        "d3-interpolate": "1 - 3",
-        "d3-timer": "1 - 3"
-      }
-    },
-    "d3-zoom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
-      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
-      "requires": {
-        "d3-dispatch": "1 - 3",
-        "d3-drag": "2 - 3",
-        "d3-interpolate": "1 - 3",
-        "d3-selection": "2 - 3",
-        "d3-transition": "2 - 3"
-      }
-    },
     "debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -4837,14 +4044,6 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
-    },
-    "delaunator": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.0.tgz",
-      "integrity": "sha512-AyLvtyJdbv/U1GkiS6gUUzclRoAY4Gs75qkMygJJhU75LW4DNuSF2RMzpxs9jw9Oz1BobHjTdkG3zdP55VxAqw==",
-      "requires": {
-        "robust-predicates": "^3.0.0"
-      }
     },
     "diff": {
       "version": "7.0.0",
@@ -5209,14 +4408,6 @@
         "debug": "4"
       }
     },
-    "iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "requires": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      }
-    },
     "ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -5256,11 +4447,6 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
-    },
-    "internmap": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
-      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="
     },
     "is-extglob": {
       "version": "2.1.1",
@@ -5773,26 +4959,11 @@
         "signal-exit": "^3.0.2"
       }
     },
-    "robust-predicates": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.1.tgz",
-      "integrity": "sha512-ndEIpszUHiG4HtDsQLeIuMvRsDnn8c8rYStabochtUeCvfuvNptb5TUbVD68LRAILPX7p9nqQGh4xJgn3EHS/g=="
-    },
-    "rw": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
-      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="
-    },
     "safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
       "dev": true
-    },
-    "safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "semver": {
       "version": "7.7.4",

--- a/package.json
+++ b/package.json
@@ -199,7 +199,7 @@
     "lint": "eslint src",
     "test": "mocha",
     "test:vscode": "node ./out/test/runTest.js",
-    "esbuild-base": "esbuild ./src/extension.ts --bundle --outfile=out/main.js --external:vscode --format=cjs --platform=node",
+    "esbuild-base": "esbuild ./src/extension.ts --bundle --outfile=out/extension.js --external:vscode --format=cjs --platform=node",
     "esbuild": "npm run esbuild-base -- --sourcemap",
     "esbuild-watch": "npm run esbuild-base -- --sourcemap --watch",
     "test-compile": "tsc -p ./"
@@ -222,8 +222,6 @@
     "ms-python.python"
   ],
   "dependencies": {
-    "d3": "^7.8.2",
-    "d3-flame-graph": "^4.0.6",
     "dotenv": "^16.3.1"
   }
 }

--- a/src/providers/flamegraph.ts
+++ b/src/providers/flamegraph.ts
@@ -136,9 +136,7 @@ export class FlameGraphViewProvider implements vscode.WebviewViewProvider {
         }
         const webview = this._view.webview;
 
-        const d3ScriptUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, 'node_modules', 'd3', 'dist', 'd3.js'));
-        const d3FlameGraphScriptUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, 'node_modules', 'd3-flame-graph', 'dist', 'd3-flamegraph.js'));
-        const d3FlameGraphCssUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, 'node_modules', 'd3-flame-graph', 'dist', 'd3-flamegraph.css'));
+        const flameGraphUtilsUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, 'media', 'flamegraph-utils.js'));
         const flameGraphScriptUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, 'media', 'flamegraph.js'));
         const austinCssUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, 'media', 'austin.css'));
         const austinLogoUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, 'media', 'austin-light.svg'));
@@ -146,7 +144,6 @@ export class FlameGraphViewProvider implements vscode.WebviewViewProvider {
         webview.html = `<!DOCTYPE html>
 			<html lang="en">
             <head>
-                <link rel="stylesheet" type="text/css" href="${d3FlameGraphCssUri}">
                 <link rel="stylesheet" type="text/css" href="${austinCssUri}">
             </head>
             <body class="logo">
@@ -154,8 +151,7 @@ export class FlameGraphViewProvider implements vscode.WebviewViewProvider {
                 <div id="chart"></div>
                 <div id="footer"></div>
 
-                <script type="text/javascript" src="${d3ScriptUri}"></script>
-                <script type="text/javascript" src="${d3FlameGraphScriptUri}"></script>
+                <script type="text/javascript" src="${flameGraphUtilsUri}"></script>
                 <script type="text/javascript" src="${flameGraphScriptUri}"></script>
             </body>
 			</html>`;

--- a/src/test/suite/flamegraph.test.ts
+++ b/src/test/suite/flamegraph.test.ts
@@ -1,0 +1,218 @@
+import * as assert from 'assert';
+import * as path from 'path';
+
+// flamegraph-utils.js uses a UMD wrapper that falls back to module.exports in Node.
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const utils = require(path.join(__dirname, '..', '..', '..', 'media', 'flamegraph-utils.js')) as {
+    hslToHex(h: number, s: number, l: number): string;
+    hash(text: string): number;
+    colorFor(node: any): string;
+    esc(text: string): string;
+    basename(path: string): string;
+    isEmpty(obj: any): boolean;
+    formatValue(v: number, mode: string): string;
+    footerText(node: any, rootValue: number, mode: string): string;
+};
+
+// ── formatValue ───────────────────────────────────────────────────────────────
+
+suite('formatValue — cpu/wall (microseconds)', () => {
+    test('sub-millisecond values in μs', () => {
+        assert.strictEqual(utils.formatValue(0, 'cpu'), '0 μs');
+        assert.strictEqual(utils.formatValue(1, 'cpu'), '1 μs');
+        assert.strictEqual(utils.formatValue(999, 'cpu'), '999 μs');
+    });
+
+    test('millisecond range in ms', () => {
+        assert.strictEqual(utils.formatValue(1000, 'cpu'), '1.00 ms');
+        assert.strictEqual(utils.formatValue(500000, 'cpu'), '500.00 ms');
+    });
+
+    test('second range in s', () => {
+        assert.strictEqual(utils.formatValue(1000000, 'cpu'), '1.00 s');
+        assert.strictEqual(utils.formatValue(2500000, 'cpu'), '2.50 s');
+    });
+
+    test('minute range in m', () => {
+        assert.strictEqual(utils.formatValue(1000000000, 'cpu'), '1.00 m');
+        assert.strictEqual(utils.formatValue(60000000000, 'cpu'), '60.00 m');
+    });
+
+    test('wall mode uses same time units', () => {
+        assert.strictEqual(utils.formatValue(1000, 'wall'), '1.00 ms');
+        assert.strictEqual(utils.formatValue(1000000, 'wall'), '1.00 s');
+    });
+});
+
+suite('formatValue — memory (bytes)', () => {
+    test('sub-kilobyte values in B', () => {
+        assert.strictEqual(utils.formatValue(0, 'memory'), '0 B');
+        assert.strictEqual(utils.formatValue(1023, 'memory'), '1023 B');
+    });
+
+    test('kilobyte range in KB', () => {
+        assert.strictEqual(utils.formatValue(1024, 'memory'), '1.00 KB');
+        assert.strictEqual(utils.formatValue(1536, 'memory'), '1.50 KB');
+    });
+
+    test('megabyte range in MB', () => {
+        assert.strictEqual(utils.formatValue(1024 * 1024, 'memory'), '1.00 MB');
+    });
+
+    test('gigabyte range in GB', () => {
+        assert.strictEqual(utils.formatValue(1024 ** 3, 'memory'), '1.00 GB');
+    });
+});
+
+// ── esc ───────────────────────────────────────────────────────────────────────
+
+suite('esc', () => {
+    test('returns empty string for falsy input', () => {
+        assert.strictEqual(utils.esc(''), '');
+    });
+
+    test('escapes ampersands', () => {
+        assert.strictEqual(utils.esc('a&b'), 'a&amp;b');
+    });
+
+    test('escapes angle brackets', () => {
+        assert.strictEqual(utils.esc('<script>'), '&lt;script&gt;');
+    });
+
+    test('leaves plain text unchanged', () => {
+        assert.strictEqual(utils.esc('hello world'), 'hello world');
+    });
+});
+
+// ── basename ──────────────────────────────────────────────────────────────────
+
+suite('basename', () => {
+    test('returns filename from Unix path', () => {
+        assert.strictEqual(utils.basename('/home/user/project/foo.py'), 'foo.py');
+    });
+
+    test('returns filename from Windows path', () => {
+        assert.strictEqual(utils.basename('C:\\Users\\user\\foo.py'), 'foo.py');
+    });
+
+    test('returns the input when there is no separator', () => {
+        assert.strictEqual(utils.basename('foo.py'), 'foo.py');
+    });
+
+    test('returns empty string for empty input', () => {
+        assert.strictEqual(utils.basename(''), '');
+    });
+});
+
+// ── hash ──────────────────────────────────────────────────────────────────────
+
+suite('hash', () => {
+    test('is deterministic', () => {
+        assert.strictEqual(utils.hash('hello'), utils.hash('hello'));
+    });
+
+    test('different inputs produce different values', () => {
+        assert.notStrictEqual(utils.hash('foo'), utils.hash('bar'));
+    });
+
+    test('returns a number', () => {
+        assert.ok(typeof utils.hash('test') === 'number');
+    });
+});
+
+// ── hslToHex ──────────────────────────────────────────────────────────────────
+
+suite('hslToHex', () => {
+    test('returns a 7-character hex string', () => {
+        const c = utils.hslToHex(0, 0, 100);
+        assert.ok(/^#[0-9a-f]{6}$/.test(c), `expected hex string, got ${c}`);
+    });
+
+    test('white is #ffffff', () => {
+        assert.strictEqual(utils.hslToHex(0, 0, 100), '#ffffff');
+    });
+
+    test('black is #000000', () => {
+        assert.strictEqual(utils.hslToHex(0, 0, 0), '#000000');
+    });
+
+    test('is deterministic', () => {
+        assert.strictEqual(utils.hslToHex(120, 50, 60), utils.hslToHex(120, 50, 60));
+    });
+});
+
+// ── colorFor ─────────────────────────────────────────────────────────────────
+
+suite('colorFor', () => {
+    test('returns grey for numeric names', () => {
+        assert.strictEqual(utils.colorFor({ name: '42' }), '#808080');
+        assert.strictEqual(utils.colorFor({ name: '0' }), '#808080');
+    });
+
+    test('returns a hex string for a Python frame', () => {
+        const c = utils.colorFor({ name: 'my_func', data: { name: 'my_func', file: '/app/foo.py' } });
+        assert.ok(/^#[0-9a-f]{6}$/.test(c), `expected hex color, got ${c}`);
+    });
+
+    test('returns a hex string for a non-Python frame', () => {
+        const c = utils.colorFor({ name: 'cfunc', data: { name: 'cfunc', file: '/lib/bar.so' } });
+        assert.ok(/^#[0-9a-f]{6}$/.test(c), `expected hex color, got ${c}`);
+    });
+
+    test('is deterministic for the same input', () => {
+        const node = { name: 'func', data: { name: 'func', file: '/app/mod.py' } };
+        assert.strictEqual(utils.colorFor(node), utils.colorFor(node));
+    });
+
+    test('returns a color for a node with no file', () => {
+        const c = utils.colorFor({ name: 'unknown' });
+        assert.ok(/^#[0-9a-f]{6}$/.test(c));
+    });
+});
+
+// ── footerText ────────────────────────────────────────────────────────────────
+
+suite('footerText', () => {
+    test('uses clock icon for cpu mode', () => {
+        const node = { name: 'fn', value: 1000, data: { name: 'fn' } };
+        assert.ok(utils.footerText(node, 10000, 'cpu').startsWith('⏱'));
+    });
+
+    test('uses package icon for memory mode', () => {
+        const node = { name: 'fn', value: 1024, data: { name: 'fn' } };
+        assert.ok(utils.footerText(node, 10240, 'memory').startsWith('📦'));
+    });
+
+    test('includes formatted value and percentage', () => {
+        const node = { name: 'fn', value: 1000, data: { name: 'fn' } };
+        const text = utils.footerText(node, 10000, 'cpu');
+        assert.ok(text.includes('1.00 ms'), `missing value in: ${text}`);
+        assert.ok(text.includes('10.00%'), `missing pct in: ${text}`);
+    });
+
+    test('includes scope name', () => {
+        const node = { name: 'my_func', value: 500, data: { name: 'my_func' } };
+        const text = utils.footerText(node, 1000, 'wall');
+        assert.ok(text.includes('my_func'), `missing scope in: ${text}`);
+    });
+
+    test('includes greyed file path when present', () => {
+        const node = { name: 'fn', value: 500, data: { name: 'fn', file: '/app/mod.py' } };
+        const text = utils.footerText(node, 1000, 'cpu');
+        assert.ok(text.includes('/app/mod.py'), `missing file in: ${text}`);
+        assert.ok(text.includes('opacity:0.45'), `missing opacity in: ${text}`);
+    });
+
+    test('omits file span when no file', () => {
+        const node = { name: 'fn', value: 500, data: { name: 'fn' } };
+        const text = utils.footerText(node, 1000, 'cpu');
+        assert.ok(!text.includes('opacity'), `unexpected opacity in: ${text}`);
+    });
+
+    test('escapes HTML in scope name', () => {
+        const node = { name: '<evil>', value: 100, data: { name: '<evil>' } };
+        const text = utils.footerText(node, 1000, 'cpu');
+        assert.ok(!text.includes('<evil>'), 'raw HTML should be escaped');
+        assert.ok(text.includes('&lt;evil&gt;'));
+    });
+});


### PR DESCRIPTION
Canvas 2D flamegraph (replaces d3-flame-graph):
- Custom Canvas 2D implementation: layout engine, hit testing, animation
- Smooth ease-in-out transitions when changing zoom focus
- Ancestor frames retained as dimmed full-width context rows when zooming
- Search highlight and hover use canvas glow/shadow effects
- System UI font (--vscode-font-family) for frame labels; file basename shown dimmer alongside function name
- Frame height adapts to VS Code UI font size (body computed font-size)
- Hover footer: metric icon + normalised value + percentage, then scope and greyed-out file path; font size set via JS from body font-size

Utility extraction and tests:
- Pure utility functions (hslToHex, hash, colorFor, esc, basename, isEmpty, formatValue, footerText) extracted to media/flamegraph-utils.js with UMD wrapper (browser global + Node.js require)
- flamegraph.js destructures only the four functions it uses directly
- New test suite src/test/suite/flamegraph.test.ts: 35 tests across 8 suites covering all utility functions

Dependency and build cleanup:
- Removed d3 and d3-flame-graph (and 43 transitive packages)
- Fixed esbuild output path: was out/main.js (never loaded), now out/extension.js to match the main field — vscode:prepublish bundle is now actually used
- Added node_modules/** and out/**/*.js.map to .vscodeignore; dotenv is bundled by esbuild so node_modules need not ship in the VSIX