### PR TITLE
feat: live profiling stats and Austin 4 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,11 +57,6 @@
           ],
           "default": "Wall time"
         },
-        "austin.binaryMode": {
-          "description": "Binary mode (MOJO output)",
-          "type": "boolean",
-          "default": false
-        },
         "austin.lineStats": {
           "description": "Line statistics",
           "type": "string",

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -3,6 +3,8 @@ import { clearDecorations, setLinesHeat } from './view';
 import { absolutePath, AustinStats } from './model';
 import { isPythonExtensionAvailable } from './utils/pythonExtension';
 import { AustinProfileTaskProvider } from './providers/task';
+import { AustinRuntimeSettings } from './settings';
+import { AustinVersionError, checkAustinVersion } from './utils/versionCheck';
 
 
 export class AustinController {
@@ -17,6 +19,17 @@ export class AustinController {
         if (!isPythonExtensionAvailable()) {
             throw Error("Python extension not available");
         }
+
+        try {
+            await checkAustinVersion(AustinRuntimeSettings.getPath());
+        } catch (e) {
+            const message = (e instanceof AustinVersionError)
+                ? e.message
+                : `Could not determine Austin version: ${(e instanceof Error) ? e.message : e}`;
+            vscode.window.showErrorMessage(message);
+            return;
+        }
+
         if (currentUri?.scheme === "file") {
             let task = this.provider.buildTaskFromUri(currentUri);
             await vscode.tasks.executeTask(task);

--- a/src/model.ts
+++ b/src/model.ts
@@ -8,7 +8,6 @@ import { isAbsolute } from 'path';
 import { Readable } from 'stream';
 import { readHead } from './utils/io';
 import { MojoParser } from './utils/mojo';
-import { AustinRuntimeSettings } from './settings';
 
 
 export class AustinSample {
@@ -43,6 +42,9 @@ export class TopStats {
     public module: string | null = null;
     public own: number = 0;
     public total: number = 0;
+    public rawOwn: number = 0;
+    public rawTotal: number = 0;
+    public rawCallerContributions: Map<string, number> = new Map();
     public callees: Map<string, TopStats> = new Map();
     public callers: Map<string, TopStats> = new Map();
     public callerContributions: Map<string, number> = new Map();
@@ -125,14 +127,14 @@ export class AustinStats implements AustinStats {
                 stats.set(key, new TopStats(fo.scope, fo.module));
             }
             let topStats = stats.get(key)!;
-            topStats.total += metric;
+            topStats.rawTotal += metric;
             if (fo.line > 0 && (topStats.minLine === 0 || fo.line < topStats.minLine)) { topStats.minLine = fo.line; }
             if (caller) {
                 const callerKey = caller.key();
                 if (!topStats.callers.has(callerKey)) {
                     topStats.callers.set(callerKey, caller);
                 }
-                topStats.callerContributions.set(callerKey, (topStats.callerContributions.get(callerKey) ?? 0) + metric);
+                topStats.rawCallerContributions.set(callerKey, (topStats.rawCallerContributions.get(callerKey) ?? 0) + metric);
             }
             caller = topStats;
         });
@@ -140,7 +142,7 @@ export class AustinStats implements AustinStats {
         // Set own time to the top of the stack
         fo = frameList[frameList.length - 1];
         let key = `${fo.module}:${fo.scope}`;
-        stats.get(key)!.own += metric;
+        stats.get(key)!.rawOwn += metric;
     }
 
     private updateLineMap(frames: FrameObject[], metric: number) {
@@ -261,27 +263,42 @@ export class AustinStats implements AustinStats {
 
     private updateCallStack(pid: number, tid: string, frameList: FrameObject[], metric: number) {
         const processNode = this.callStack.callees.getDefault(pid.toString(), () => new TopStats(`Process ${pid}`, ""));
-        processNode.total += metric;
+        processNode.rawTotal += metric;
         let current = processNode.callees.getDefault(tid, () => new TopStats(`Thread ${tid}`, ""));
-        current.total += metric;
+        current.rawTotal += metric;
 
         frameList.forEach((fo, idx) => {
             const key = `${fo.module}:${fo.scope}`;
             const callee = current.callees.getDefault(key, () => new TopStats(fo.scope, fo.module));
             if (fo.line > 0 && (callee.minLine === 0 || fo.line < callee.minLine)) { callee.minLine = fo.line; }
-            callee.total += metric;
+            callee.rawTotal += metric;
             if (idx === frameList.length - 1) {
-                callee.own += metric;
+                callee.rawOwn += metric;
             }
             current = callee;
         });
     }
 
-    private normalizeCallStack(node: TopStats): void {
-        node.own /= this.overallTotal;
-        node.total /= this.overallTotal;
+    private normalizeCallStackNode(node: TopStats): void {
+        node.own = node.rawOwn / this.overallTotal;
+        node.total = node.rawTotal / this.overallTotal;
         for (const child of node.callees.values()) {
-            this.normalizeCallStack(child);
+            this.normalizeCallStackNode(child);
+        }
+    }
+
+    private normalizeAll() {
+        if (this.overallTotal === 0) { return; }
+        const total = this.overallTotal;
+        for (const s of this.top.values()) {
+            s.own = s.rawOwn / total;
+            s.total = s.rawTotal / total;
+            for (const [k, v] of s.rawCallerContributions) {
+                s.callerContributions.set(k, v / total);
+            }
+        }
+        for (const child of this.callStack.callees.values()) {
+            this.normalizeCallStackNode(child);
         }
     }
 
@@ -309,22 +326,31 @@ export class AustinStats implements AustinStats {
         this._afterCbs.push(cb);
     }
 
+    public registerOnceAfterCallback(cb: (stats: AustinStats) => void) {
+        const wrapper = (stats: AustinStats) => {
+            cb(stats);
+            this._afterCbs = this._afterCbs.filter(c => c !== wrapper);
+        };
+        this._afterCbs.push(wrapper);
+    }
+
+    public begin(fileName: string) {
+        this.source = fileName;
+        this.clear();
+        this._beforeCbs.forEach(cb => cb());
+    }
+
+    public refresh() {
+        this.normalizeAll();
+        this._afterCbs.forEach(cb => cb(this));
+    }
+
     private finalize() {
-        [...this.top.values()].forEach(v => {
-            v.own /= this.overallTotal;
-            v.total /= this.overallTotal;
-            for (const [k, val] of v.callerContributions) {
-                v.callerContributions.set(k, val / this.overallTotal);
-            }
-        });
-        for (const child of this.callStack.callees.values()) {
-            this.normalizeCallStack(child);
-        }
-        this._afterCbs.forEach((cb) => cb(this));
+        this.refresh();
     }
 
     public readFromBuffer(buffer: Buffer, fileName: string) {
-        if (AustinRuntimeSettings.get().settings.binaryMode) {
+        if (buffer.length >= 3 && buffer.slice(0, 3).toString() === "MOJ") {
             this.readFromMojoStream(buffer.values(), fileName);
         } else {
             let stream = new Readable();

--- a/src/providers/executor.ts
+++ b/src/providers/executor.ts
@@ -4,6 +4,7 @@ import { AustinCommandArguments } from "../utils/commandFactory";
 
 import { ChildProcess, spawn } from "child_process";
 import { AustinStats } from "../model";
+import { StreamingMojoParser } from "../utils/mojo";
 import { clearDecorations, setLinesHeat } from "../view";
 
 import { DotenvPopulateInput, config } from "dotenv";
@@ -30,10 +31,7 @@ function resolveArgs(args: string[]): string[] {
 
 export class AustinCommandExecutor implements vscode.Pseudoterminal {
   private austinProcess: ChildProcess | undefined;
-  stderr: string | undefined;
-  stdout: string | undefined;
   result: number = 0;
-  buffer: Buffer = Buffer.alloc(0);
 
   constructor(
     private command: AustinCommandArguments,
@@ -48,30 +46,10 @@ export class AustinCommandExecutor implements vscode.Pseudoterminal {
   private closeEmitter = new vscode.EventEmitter<number>();
   onDidClose?: vscode.Event<number> = this.closeEmitter.event;
 
-  private fileWatcher: vscode.FileSystemWatcher | undefined;
-
-  private showStats() {
-    clearDecorations();
-    try {
-      this.stats.readFromBuffer(this.buffer, this.fileName || "");
-    } catch (e) {
-      let message = (e instanceof Error) ? e.message : e;
-      vscode.window.showErrorMessage(`Failed to parse stats from ${this.fileName}: ${message}`);
-      return;
-    }
-    if (this.fileName) {
-      const lines = this.stats.locationMap.get(this.fileName);
-      if (lines) {
-        setLinesHeat(lines, this.stats);
-      }
-    }
-  }
-
   open(initialDimensions: vscode.TerminalDimensions | undefined): void {
     this.writeEmitter.fire(`Starting Profiler in ${this.cwd}.\r\n`);
     let resolvedArgs = resolveArgs(this.command.args);
 
-    // Make a copy of all defined environment variables
     let env: DotenvPopulateInput = {};
     for (let key in process.env) {
       let value = process.env[key];
@@ -79,8 +57,6 @@ export class AustinCommandExecutor implements vscode.Pseudoterminal {
         env[key] = value;
       }
     }
-
-    // Add any environment variables defined in the envFile, if any given
     if (this.command.envFile) {
       config({ path: this.command.envFile, processEnv: env });
     }
@@ -94,27 +70,51 @@ export class AustinCommandExecutor implements vscode.Pseudoterminal {
     if (!this.fileName) {
       this.fileName = `${this.command.cmd} ${args}`;
     }
+    const fileName = this.fileName;
+
     if (this.austinProcess) {
       this.austinProcess.on("error", (err) => {
         this.writeEmitter.fire(err.message);
-      });
-      this.austinProcess.stdout!.on("data", (data) => {
-        this.buffer = Buffer.concat([this.buffer, data]);
       });
 
       this.austinProcess.stderr!.on("data", (data) => {
         this.output.append(data.toString());
       });
 
+      clearDecorations();
+      this.stats.begin(fileName);
+      const parser = new StreamingMojoParser(this.stats);
+
+      this.austinProcess.stdout!.on("data", (chunk: Buffer) => {
+        parser.push(chunk);
+      });
+
+      let lastTotal = 0;
+      const refreshInterval = setInterval(() => {
+        if (this.stats.overallTotal > lastTotal) {
+          lastTotal = this.stats.overallTotal;
+          this.stats.refresh();
+        }
+      }, 1000);
+
       this.austinProcess.on("close", (code) => {
+        clearInterval(refreshInterval);
         if (code !== 0) {
           this.writeEmitter.fire(`austin process exited with code ${code}\r\n`);
-          this.result = code;
-          this.closeEmitter.fire(code);
+          this.result = code!;
+          this.closeEmitter.fire(code!);
+          vscode.window.showErrorMessage(`Austin exited with code ${code}. Check the Austin output channel for details.`);
         } else {
           this.writeEmitter.fire("Profiling complete.\r\n");
-          this.closeEmitter.fire(code);
-          this.showStats();
+          this.closeEmitter.fire(0);
+          const label = fileName ? vscode.workspace.asRelativePath(fileName) : "script";
+          vscode.window.showInformationMessage(`Profiling of ${label} done.`);
+          parser.finalize();
+          this.stats.refresh();
+          if (fileName) {
+            const lines = this.stats.locationMap.get(fileName);
+            if (lines) { setLinesHeat(lines, this.stats); }
+          }
         }
       });
     } else {
@@ -126,9 +126,6 @@ export class AustinCommandExecutor implements vscode.Pseudoterminal {
 
   close(): void {
     // The terminal has been closed. Shutdown the build.
-    if (this.fileWatcher) {
-      this.fileWatcher.dispose();
-    }
     if (this.austinProcess && !this.austinProcess.killed) {
       this.austinProcess.kill();
     }

--- a/src/providers/task.ts
+++ b/src/providers/task.ts
@@ -4,6 +4,7 @@ import { AustinCommandExecutor } from "./executor";
 import { AustinStats } from "../model";
 import { isPythonExtensionAvailable } from "../utils/pythonExtension";
 import { AustinMode } from "../types";
+import { AustinRuntimeSettings } from "../settings";
 import { isAbsolute } from "path";
 import { platform } from "os";
 
@@ -24,7 +25,12 @@ export class AustinProfileTaskProvider implements vscode.TaskProvider {
 
   public buildTaskFromUri(path: vscode.Uri) {
     return this.buildTask(
-      { file: path.fsPath, type: "austin", command: platform() === "darwin" ? ["sudo"] : undefined },
+      {
+        file: path.fsPath,
+        type: "austin",
+        command: platform() === "darwin" ? ["sudo"] : undefined,
+        mode: AustinRuntimeSettings.getMode(),
+      },
       vscode.TaskScope.Workspace,
     );
   }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -19,14 +19,12 @@ export class AustinRuntimeSettings {
         }
         const austinInterval: number = AustinRuntimeSettings.config.get<number>("interval", DEFAULT_INTERVAL);
         const austinMode: AustinMode = AustinRuntimeSettings.config.get("mode", DEFAULT_MODE);
-        const austinBinaryMode: boolean = AustinRuntimeSettings.config.get("binaryMode", false);
         const austinLineStats: AustinLineStats = AustinRuntimeSettings.config.get("lineStats", DEFAULT_LINE_STATS);
 
         this.settings = {
             path: austinPath,
             mode: austinMode,
             interval: austinInterval,
-            binaryMode: austinBinaryMode,
             lineStats: austinLineStats
         };
     }
@@ -42,7 +40,7 @@ export class AustinRuntimeSettings {
     }
 
     public static setPath(newPath: string) {
-        AustinRuntimeSettings.config.update("path", newPath);
+        AustinRuntimeSettings.config.update("path", newPath, vscode.ConfigurationTarget.Global);
     }
 
     public static getInterval(): number {
@@ -50,7 +48,7 @@ export class AustinRuntimeSettings {
     }
 
     public static setInterval(newInterval: number) {
-        AustinRuntimeSettings.config.update("interval", newInterval);
+        AustinRuntimeSettings.config.update("interval", newInterval, vscode.ConfigurationTarget.Global);
     }
 
     public static getMode(): AustinMode {
@@ -58,15 +56,7 @@ export class AustinRuntimeSettings {
     }
 
     public static setMode(newMode: AustinMode) {
-        AustinRuntimeSettings.config.update("mode", newMode);
-    }
-
-    public static getBinaryMode(): boolean {
-        return AustinRuntimeSettings.get().settings.binaryMode;
-    }
-
-    public static setBinaryMode(newBinaryMode: boolean) {
-        AustinRuntimeSettings.config.update("binaryMode", newBinaryMode);
+        AustinRuntimeSettings.config.update("mode", newMode, vscode.ConfigurationTarget.Global);
     }
 
     public static getLineStats(): AustinLineStats {
@@ -74,6 +64,6 @@ export class AustinRuntimeSettings {
     }
 
     public static setLineStats(newLineStats: AustinLineStats) {
-        AustinRuntimeSettings.config.update("lineStats", newLineStats);
+        AustinRuntimeSettings.config.update("lineStats", newLineStats, vscode.ConfigurationTarget.Global);
     }
 }

--- a/src/test/suite/model.test.ts
+++ b/src/test/suite/model.test.ts
@@ -137,8 +137,8 @@ suite('AustinStats.update', () => {
         const inner = { module: '/m.py', scope: 'inner', line: 2 };
         stats.update(1, 'T1', [outer, inner], 100);
 
-        assert.strictEqual(stats.top.get('/m.py:outer')!.own, 0);
-        assert.strictEqual(stats.top.get('/m.py:inner')!.own, 100);
+        assert.strictEqual(stats.top.get('/m.py:outer')!.rawOwn, 0);
+        assert.strictEqual(stats.top.get('/m.py:inner')!.rawOwn, 100);
     });
 
     test('total time is accumulated on every frame in the stack', () => {
@@ -147,8 +147,8 @@ suite('AustinStats.update', () => {
         const inner = { module: '/m.py', scope: 'inner', line: 2 };
         stats.update(1, 'T1', [outer, inner], 100);
 
-        assert.strictEqual(stats.top.get('/m.py:outer')!.total, 100);
-        assert.strictEqual(stats.top.get('/m.py:inner')!.total, 100);
+        assert.strictEqual(stats.top.get('/m.py:outer')!.rawTotal, 100);
+        assert.strictEqual(stats.top.get('/m.py:inner')!.rawTotal, 100);
     });
 
     test('recursive frames are counted only once (no double-counting)', () => {
@@ -156,8 +156,8 @@ suite('AustinStats.update', () => {
         const frame = { module: '/m.py', scope: 'recursive', line: 5 };
         stats.update(1, 'T1', [frame, frame], 200);
 
-        assert.strictEqual(stats.top.get('/m.py:recursive')!.total, 200);
-        assert.strictEqual(stats.top.get('/m.py:recursive')!.own, 200);
+        assert.strictEqual(stats.top.get('/m.py:recursive')!.rawTotal, 200);
+        assert.strictEqual(stats.top.get('/m.py:recursive')!.rawOwn, 200);
     });
 
     test('locationMap is populated with module key', () => {
@@ -250,5 +250,90 @@ suite('AustinStats.readFromStream', () => {
         const stats = new AustinStats();
         stats.setMetadata('version', '3');
         assert.strictEqual(stats.metadata.get('version'), '3');
+    });
+});
+
+
+// ---------------------------------------------------------------------------
+// AustinStats.refresh — normalisation and idempotency
+// ---------------------------------------------------------------------------
+suite('AustinStats.refresh', () => {
+
+    test('normalises own and total as fractions after update', () => {
+        const stats = new AustinStats();
+        const outer = { module: '/m.py', scope: 'outer', line: 1 };
+        const inner = { module: '/m.py', scope: 'inner', line: 2 };
+        stats.update(1, 'T1', [outer, inner], 100);
+        stats.refresh();
+        assert.strictEqual(stats.top.get('/m.py:outer')!.total, 1.0);
+        assert.strictEqual(stats.top.get('/m.py:inner')!.total, 1.0);
+        assert.strictEqual(stats.top.get('/m.py:outer')!.own, 0.0);
+        assert.strictEqual(stats.top.get('/m.py:inner')!.own, 1.0);
+    });
+
+    test('refresh() is idempotent — calling it twice gives the same result', () => {
+        const stats = new AustinStats();
+        const frame = { module: '/m.py', scope: 'fn', line: 1 };
+        stats.update(1, 'T1', [frame], 200);
+        stats.refresh();
+        const afterFirst = stats.top.get('/m.py:fn')!.own;
+        stats.refresh();
+        const afterSecond = stats.top.get('/m.py:fn')!.own;
+        assert.strictEqual(afterFirst, afterSecond);
+    });
+
+    test('raw fields remain unchanged after refresh()', () => {
+        const stats = new AustinStats();
+        const frame = { module: '/m.py', scope: 'fn', line: 1 };
+        stats.update(1, 'T1', [frame], 300);
+        stats.refresh();
+        assert.strictEqual(stats.top.get('/m.py:fn')!.rawOwn, 300);
+        assert.strictEqual(stats.top.get('/m.py:fn')!.rawTotal, 300);
+    });
+
+    test('refresh() fires after-callbacks', () => {
+        const stats = new AustinStats();
+        let called = 0;
+        stats.registerAfterCallback(() => { called++; });
+        stats.update(1, 'T1', [], 10);
+        stats.refresh();
+        assert.strictEqual(called, 1);
+    });
+
+    test('registerOnceAfterCallback fires exactly once', () => {
+        const stats = new AustinStats();
+        let called = 0;
+        stats.registerOnceAfterCallback(() => { called++; });
+        stats.refresh();
+        stats.refresh();
+        assert.strictEqual(called, 1);
+    });
+});
+
+
+// ---------------------------------------------------------------------------
+// AustinStats.begin — session initialisation
+// ---------------------------------------------------------------------------
+suite('AustinStats.begin', () => {
+
+    test('begin() clears previously accumulated data', async () => {
+        const stats = await readStats('P1;T1;/a.py:f:1 100\n');
+        stats.begin('new.austin');
+        assert.strictEqual(stats.overallTotal, 0);
+        assert.strictEqual(stats.top.size, 0);
+    });
+
+    test('begin() sets the source to the new file name', () => {
+        const stats = new AustinStats();
+        stats.begin('profile.austin');
+        assert.strictEqual(stats.source, 'profile.austin');
+    });
+
+    test('begin() fires before-callbacks', () => {
+        const stats = new AustinStats();
+        let called = 0;
+        stats.registerBeforeCallback(() => { called++; });
+        stats.begin('x.austin');
+        assert.strictEqual(called, 1);
     });
 });

--- a/src/test/suite/streaming-mojo.test.ts
+++ b/src/test/suite/streaming-mojo.test.ts
@@ -1,0 +1,260 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import { StreamingMojoParser } from '../../utils/mojo';
+import { AustinStats } from '../../model';
+import { testDataPath } from './helpers';
+import '../../stringExtension';
+import '../../mapExtension';
+
+
+// ---------------------------------------------------------------------------
+// Helpers (mirrored from mojo.test.ts)
+// ---------------------------------------------------------------------------
+
+function vi(n: number): number {
+    assert.ok(n >= 0 && n <= 63, `vi() only handles 0–63, got ${n}`);
+    return n;
+}
+
+function varIntBytes(n: number): number[] {
+    assert.ok(n >= 0, 'varIntBytes only handles non-negative');
+    if (n <= 63) { return [n]; }
+    const lo = 0x80 | (n & 0x3F);
+    const hi = (n >> 6) & 0x7F;
+    return [lo, hi];
+}
+
+function str(s: string): number[] {
+    return [...s].map(c => c.charCodeAt(0)).concat([0]);
+}
+
+/** Feed the byte array to a StreamingMojoParser as a single chunk. */
+function parseWithStreaming(bytes: number[]): AustinStats {
+    const stats = new AustinStats();
+    const parser = new StreamingMojoParser(stats);
+    parser.push(Buffer.from(bytes));
+    parser.finalize();
+    return stats;
+}
+
+/** Feed the byte array byte-by-byte. */
+function parseByteByByte(bytes: number[]): AustinStats {
+    const stats = new AustinStats();
+    const parser = new StreamingMojoParser(stats);
+    for (const b of bytes) {
+        parser.push(Buffer.from([b]));
+    }
+    parser.finalize();
+    return stats;
+}
+
+// Shared minimal v1 MOJO stream with one sample:
+//   pid=1, tid="T1", frame={/test.py:foo:10}, time=100
+function buildV1Stream(): number[] {
+    return [
+        // Header
+        0x4D, 0x4F, 0x4A,         // "MOJ"
+        vi(1),                     // version = 1
+
+        // metadata: mode=wall
+        vi(1),                     // MOJO_EVENT.metadata
+        ...str('mode'),
+        ...str('wall'),
+
+        // stack: pid=1, tid="T1"
+        vi(2),                     // MOJO_EVENT.stack
+        vi(1),                     // pid = 1
+        ...str('T1'),              // tid
+
+        // string: key=2 → "/test.py"
+        vi(11),                    // MOJO_EVENT.string
+        vi(2),
+        ...str('/test.py'),
+
+        // string: key=3 → "foo"
+        vi(11),                    // MOJO_EVENT.string
+        vi(3),
+        ...str('foo'),
+
+        // frame: key=1, filenameKey=2, scopeKey=3, line=10
+        vi(3),                     // MOJO_EVENT.frame
+        vi(1),
+        vi(2),
+        vi(3),
+        vi(10),
+
+        // frameReference: key=1
+        vi(5),                     // MOJO_EVENT.frameReference
+        vi(1),
+
+        // time: 100
+        vi(9),                     // MOJO_EVENT.time
+        ...varIntBytes(100),
+    ];
+}
+
+
+// ---------------------------------------------------------------------------
+// StreamingMojoParser — single-chunk
+// ---------------------------------------------------------------------------
+suite('StreamingMojoParser — single chunk', () => {
+
+    test('parses a complete stream fed as one chunk', () => {
+        const stats = parseWithStreaming(buildV1Stream());
+        assert.strictEqual(stats.overallTotal, 100);
+    });
+
+    test('populates top for the frame in the stream', () => {
+        const stats = parseWithStreaming(buildV1Stream());
+        assert.ok(stats.top.has('/test.py:foo'), 'top should contain /test.py:foo');
+    });
+
+    test('populates locationMap for the module', () => {
+        const stats = parseWithStreaming(buildV1Stream());
+        assert.ok(stats.locationMap.has('/test.py'), 'locationMap should contain /test.py');
+    });
+
+    test('stores metadata from the stream', () => {
+        const stats = parseWithStreaming(buildV1Stream());
+        assert.strictEqual(stats.metadata.get('mode'), 'wall');
+    });
+
+    test('finalize() commits the last in-flight sample', () => {
+        const stats = new AustinStats();
+        const parser = new StreamingMojoParser(stats);
+        // Feed the whole stream but do NOT call finalize yet
+        parser.push(Buffer.from(buildV1Stream()));
+        // The last sample is buffered; overallTotal is still 0 until finalize
+        assert.strictEqual(stats.overallTotal, 0, 'sample not committed before finalize');
+        parser.finalize();
+        assert.strictEqual(stats.overallTotal, 100, 'sample committed after finalize');
+    });
+
+    test('finalize() is a no-op when no sample is in flight', () => {
+        const stats = new AustinStats();
+        const parser = new StreamingMojoParser(stats);
+        // Empty push + finalize should not throw
+        parser.push(Buffer.alloc(0));
+        assert.doesNotThrow(() => parser.finalize());
+        assert.strictEqual(stats.overallTotal, 0);
+    });
+});
+
+
+// ---------------------------------------------------------------------------
+// StreamingMojoParser — byte-by-byte (partial-event rollback)
+// ---------------------------------------------------------------------------
+suite('StreamingMojoParser — byte-by-byte', () => {
+
+    test('produces same overallTotal as single-chunk when fed byte-by-byte', () => {
+        const bytes = buildV1Stream();
+        const single = parseWithStreaming(bytes);
+        const streamed = parseByteByByte(bytes);
+        assert.strictEqual(streamed.overallTotal, single.overallTotal);
+    });
+
+    test('produces same top entries as single-chunk when fed byte-by-byte', () => {
+        const bytes = buildV1Stream();
+        const single = parseWithStreaming(bytes);
+        const streamed = parseByteByByte(bytes);
+        assert.deepStrictEqual([...streamed.top.keys()].sort(), [...single.top.keys()].sort());
+    });
+
+    test('produces same locationMap keys as single-chunk when fed byte-by-byte', () => {
+        const bytes = buildV1Stream();
+        const single = parseWithStreaming(bytes);
+        const streamed = parseByteByByte(bytes);
+        assert.deepStrictEqual([...streamed.locationMap.keys()].sort(), [...single.locationMap.keys()].sort());
+    });
+});
+
+
+// ---------------------------------------------------------------------------
+// StreamingMojoParser — split at specific boundaries
+// ---------------------------------------------------------------------------
+suite('StreamingMojoParser — split chunks', () => {
+
+    test('header split across two chunks is handled correctly', () => {
+        const bytes = buildV1Stream();
+        const stats = new AustinStats();
+        const parser = new StreamingMojoParser(stats);
+        // Split after first two header bytes ("MO")
+        parser.push(Buffer.from(bytes.slice(0, 2)));
+        parser.push(Buffer.from(bytes.slice(2)));
+        parser.finalize();
+        assert.strictEqual(stats.overallTotal, 100);
+    });
+
+    test('varint split across chunk boundary is handled correctly', () => {
+        const bytes = buildV1Stream();
+        // The time varint for 100 requires two bytes (>63); split right before it
+        const split = bytes.length - 2;
+        const stats = new AustinStats();
+        const parser = new StreamingMojoParser(stats);
+        parser.push(Buffer.from(bytes.slice(0, split)));
+        parser.push(Buffer.from(bytes.slice(split)));
+        parser.finalize();
+        assert.strictEqual(stats.overallTotal, 100);
+    });
+
+    test('null-terminated string split across chunk boundary is handled correctly', () => {
+        const bytes = buildV1Stream();
+        // Split mid-way through the tid string "T1\0"
+        const split = bytes.indexOf(str('T1')[0]);
+        const stats = new AustinStats();
+        const parser = new StreamingMojoParser(stats);
+        parser.push(Buffer.from(bytes.slice(0, split + 1)));
+        parser.push(Buffer.from(bytes.slice(split + 1)));
+        parser.finalize();
+        assert.strictEqual(stats.overallTotal, 100);
+    });
+});
+
+
+// ---------------------------------------------------------------------------
+// StreamingMojoParser — real data file
+// ---------------------------------------------------------------------------
+suite('StreamingMojoParser — real data file', () => {
+
+    test('produces same overallTotal as MojoParser when fed in 16-byte chunks', () => {
+        const filePath = testDataPath('test.mojo');
+        if (!fs.existsSync(filePath)) { return; }
+
+        const data = fs.readFileSync(filePath);
+
+        // Reference: synchronous MojoParser via readFromMojoStream
+        const refStats = new AustinStats();
+        refStats.readFromMojoStream(data.values() as IterableIterator<number>, filePath);
+
+        // Streaming: feed in 16-byte chunks
+        const stats = new AustinStats();
+        const parser = new StreamingMojoParser(stats);
+        const chunkSize = 16;
+        for (let i = 0; i < data.length; i += chunkSize) {
+            parser.push(data.slice(i, i + chunkSize));
+        }
+        parser.finalize();
+
+        assert.strictEqual(stats.overallTotal, refStats.overallTotal);
+    });
+
+    test('produces same top keys as MojoParser when fed in 32-byte chunks', () => {
+        const filePath = testDataPath('test.mojo');
+        if (!fs.existsSync(filePath)) { return; }
+
+        const data = fs.readFileSync(filePath);
+
+        const refStats = new AustinStats();
+        refStats.readFromMojoStream(data.values() as IterableIterator<number>, filePath);
+
+        const stats = new AustinStats();
+        const parser = new StreamingMojoParser(stats);
+        const chunkSize = 32;
+        for (let i = 0; i < data.length; i += chunkSize) {
+            parser.push(data.slice(i, i + chunkSize));
+        }
+        parser.finalize();
+
+        assert.deepStrictEqual([...stats.top.keys()].sort(), [...refStats.top.keys()].sort());
+    });
+});

--- a/src/test/suite/versionCheck.test.ts
+++ b/src/test/suite/versionCheck.test.ts
@@ -1,0 +1,83 @@
+import * as assert from 'assert';
+import * as path from 'path';
+import * as os from 'os';
+import * as fs from 'fs';
+import { checkAustinVersion, AustinVersionError } from '../../utils/versionCheck';
+
+
+// ---------------------------------------------------------------------------
+// Helper: create a fake "austin" executable that prints `versionLine` to
+// stdout and exits 0, ignoring any arguments passed to it.
+//
+// On Unix: a shebang script (directly executable via execFile).
+// On Windows: a .cmd file — Node's execFile spawns .cmd/.bat files through
+// cmd.exe automatically, so no shell:true is required.
+// ---------------------------------------------------------------------------
+function makeFakeAustin(versionLine: string): string {
+    const dir = os.tmpdir();
+    const id = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+    if (process.platform === 'win32') {
+        const scriptPath = path.join(dir, `fake-austin-${id}.cmd`);
+        fs.writeFileSync(scriptPath, `@echo off\necho ${versionLine}\n`);
+        return scriptPath;
+    }
+
+    const scriptPath = path.join(dir, `fake-austin-${id}.sh`);
+    fs.writeFileSync(
+        scriptPath,
+        `#!/bin/sh\necho '${versionLine}'\n`
+    );
+    fs.chmodSync(scriptPath, 0o755);
+    return scriptPath;
+}
+
+
+// ---------------------------------------------------------------------------
+// checkAustinVersion
+// ---------------------------------------------------------------------------
+suite('checkAustinVersion', () => {
+
+    test('resolves for austin 4.0.0', () => {
+        return assert.doesNotReject(
+            checkAustinVersion(makeFakeAustin('austin 4.0.0'))
+        );
+    });
+
+    test('resolves for a newer version like 5.1.2', () => {
+        return assert.doesNotReject(
+            checkAustinVersion(makeFakeAustin('austin 5.1.2'))
+        );
+    });
+
+    test('rejects with AustinVersionError for version 3.6.0', () => {
+        return assert.rejects(
+            checkAustinVersion(makeFakeAustin('austin 3.6.0')),
+            (err: unknown) => err instanceof AustinVersionError
+        );
+    });
+
+    test('AustinVersionError carries the version string', async () => {
+        try {
+            await checkAustinVersion(makeFakeAustin('austin 3.6.0'));
+            assert.fail('should have thrown');
+        } catch (err) {
+            assert.ok(err instanceof AustinVersionError);
+            assert.strictEqual(err.version, '3.6.0');
+        }
+    });
+
+    test('rejects with a generic Error for unparseable output', () => {
+        return assert.rejects(
+            checkAustinVersion(makeFakeAustin('not a version string')),
+            /Could not parse Austin version/
+        );
+    });
+
+    test('rejects when the binary cannot be found', () => {
+        return assert.rejects(
+            checkAustinVersion('/non/existent/binary'),
+            /Failed to run/
+        );
+    });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,5 @@ export class AustinSettings {
     path: string = "austin";
     mode: AustinMode = AustinMode.CpuTime;
     interval: number = 100;
-    binaryMode: boolean = false;
-    lineStats: AustinLineStats = AustinLineStats.PERCENT;
+lineStats: AustinLineStats = AustinLineStats.PERCENT;
 }

--- a/src/utils/commandFactory.ts
+++ b/src/utils/commandFactory.ts
@@ -35,9 +35,8 @@ export function getAustinCommand(
 
     _args = _args.concat(["-i", `${_interval}`, `--pipe`]);
 
-    if (_mode === AustinMode.CpuTime) { _args.push("-s"); }
+    if (_mode === AustinMode.CpuTime) { _args.push("-c"); }
     if (_mode === AustinMode.Memory) { _args.push("-m"); }
-    if (settings.binaryMode) { _args.push("-b"); }
     if (austinArgs) { _args = _args.concat(austinArgs); }
     if (pythonFile) {
         _args.push(getConfiguredInterpreter());

--- a/src/utils/mojo.ts
+++ b/src/utils/mojo.ts
@@ -386,6 +386,12 @@ export class StreamingMojoParser {
                 break;
             }
             case MOJO_EVENT.stack: {
+                // Read all new state before committing the old sample.
+                // If any read throws IteratorDone mid-event, the offset rolls
+                // back to the tag byte and no state changes take effect.
+                const newPid = this.consumeVarInt();
+                const newIid = this.version! >= 3n ? this.consumeVarInt() : 0n;
+                const newTid = this.consumeString();
                 if (this.currentPid !== null) {
                     this.stats.update(
                         Number(this.currentPid),
@@ -395,10 +401,10 @@ export class StreamingMojoParser {
                     );
                     this.previousStacks.set(this.currentStackKey!, this.currentStack);
                 }
-                this.currentPid = this.consumeVarInt();
-                this.currentIid = this.version! >= 3n ? this.consumeVarInt() : 0n;
-                this.currentTid = this.consumeString();
-                this.currentStackKey = `${this.currentPid}:${this.currentIid}:${this.currentTid}`;
+                this.currentPid = newPid;
+                this.currentIid = newIid;
+                this.currentTid = newTid;
+                this.currentStackKey = `${newPid}:${newIid}:${newTid}`;
                 this.currentStack = [];
                 this.currentTimeMetric = null;
                 this.currentMemoryMetric = null;

--- a/src/utils/mojo.ts
+++ b/src/utils/mojo.ts
@@ -287,3 +287,212 @@ export class MojoParser {
         }
     }
 }
+
+export class StreamingMojoParser {
+    private pending: Buffer = Buffer.alloc(0);
+    private offset = 0;
+    private version: bigint | null = null;
+
+    private frameRefs = new Map<string, FrameObject>();
+    private stringRefs = new Map<string, string>();
+
+    private currentPid: bigint | null = null;
+    private currentIid: bigint | null = null;
+    private currentTid: string | null = null;
+    private currentStack: FrameObject[] = [];
+    private currentStackKey: string | null = null;
+    private currentTimeMetric: bigint | null = null;
+    private currentMemoryMetric: bigint | null = null;
+    private mode: string | null = null;
+    private previousStacks = new Map<string, FrameObject[]>();
+    private invalidFrame = false;
+
+    constructor(private readonly stats: AustinStats) {}
+
+    private consume(): number {
+        if (this.offset >= this.pending.length) {
+            throw new IteratorDone();
+        }
+        return this.pending[this.offset++];
+    }
+
+    private consumeVarInt(): bigint {
+        let n: bigint = 0n;
+        let s = 6n;
+        let b = BigInt(this.consume());
+        const sign = (b & 0x40n);
+        n |= (b & 0x3Fn);
+        while (b & 0x80n) {
+            b = BigInt(this.consume());
+            n |= ((b & 0x7Fn) << s);
+            s += 7n;
+        }
+        return sign ? -n : n;
+    }
+
+    private consumeString(): string {
+        const bs: number[] = [];
+        while (true) {
+            const b = this.consume();
+            if (b === 0) { break; }
+            bs.push(b);
+        }
+        return String.fromCharCode(...bs);
+    }
+
+    private consumeHeader(): void {
+        if (this.consume() !== ord('M') || this.consume() !== ord('O') || this.consume() !== ord('J')) {
+            throw new Error("Invalid MOJO header");
+        }
+        this.version = this.consumeVarInt();
+    }
+
+    private consumeFrame(): FrameData {
+        const key = this.consumeVarInt();
+        const filenameKey = this.consumeVarInt();
+        const scopeKey = this.consumeVarInt();
+        const line = this.consumeVarInt();
+        let lineEnd = 0n, column = 0n, columnEnd = 0n;
+        if (this.version! >= 2n) {
+            lineEnd = this.consumeVarInt();
+            column = this.consumeVarInt();
+            columnEnd = this.consumeVarInt();
+        }
+        const filename = this.stringRefs.get(`${this.currentPid}:${filenameKey}`);
+        const scope = (scopeKey === 1n) ? "<unknown>" : this.stringRefs.get(`${this.currentPid}:${scopeKey}`);
+        if (filename === undefined || scope === undefined) {
+            throw new Error("Invalid string references in frame event");
+        }
+        return {
+            key,
+            frame: {
+                module: filename,
+                scope,
+                line: Number(line),
+                lineEnd: Number(lineEnd),
+                column: Number(column),
+                columnEnd: Number(columnEnd),
+            }
+        };
+    }
+
+    private processOneEvent(): void {
+        switch (this.consume()) {
+            case MOJO_EVENT.metadata: {
+                const k = this.consumeString();
+                const v = this.consumeString();
+                this.stats.setMetadata(k, v);
+                if (k === "mode") { this.mode = v; }
+                break;
+            }
+            case MOJO_EVENT.stack: {
+                if (this.currentPid !== null) {
+                    this.stats.update(
+                        Number(this.currentPid),
+                        `${this.currentIid}:${this.currentTid}`,
+                        this.currentStack,
+                        Number(this.mode === "memory" ? this.currentMemoryMetric! : this.currentTimeMetric!),
+                    );
+                    this.previousStacks.set(this.currentStackKey!, this.currentStack);
+                }
+                this.currentPid = this.consumeVarInt();
+                this.currentIid = this.version! >= 3n ? this.consumeVarInt() : 0n;
+                this.currentTid = this.consumeString();
+                this.currentStackKey = `${this.currentPid}:${this.currentIid}:${this.currentTid}`;
+                this.currentStack = [];
+                this.currentTimeMetric = null;
+                this.currentMemoryMetric = null;
+                this.invalidFrame = false;
+                break;
+            }
+            case MOJO_EVENT.frame: {
+                if (this.currentPid === null) { throw new Error("Frame before stack"); }
+                const fd = this.consumeFrame();
+                this.frameRefs.set(`${this.currentPid}:${fd.key}`, fd.frame);
+                break;
+            }
+            case MOJO_EVENT.invalidFrame: {
+                if (this.previousStacks.has(this.currentStackKey!)) {
+                    this.currentStack = this.previousStacks.get(this.currentStackKey!)!;
+                    this.invalidFrame = true;
+                } else {
+                    this.currentStack.push(specialFrame("INVALID"));
+                }
+                break;
+            }
+            case MOJO_EVENT.frameReference: {
+                const key = `${this.currentPid}:${this.consumeVarInt()}`;
+                if (!this.invalidFrame) {
+                    this.currentStack.push(this.frameRefs.get(key)!);
+                }
+                break;
+            }
+            case MOJO_EVENT.kernelFrame: {
+                const kf = { module: "kernel", scope: this.consumeString(), line: 0 };
+                if (!this.invalidFrame) { this.currentStack.push(kf); }
+                break;
+            }
+            case MOJO_EVENT.gc:
+                this.currentStack.push(specialFrame("GC"));
+                break;
+            case MOJO_EVENT.idle:
+                break;
+            case MOJO_EVENT.time:
+                this.currentTimeMetric = this.consumeVarInt();
+                break;
+            case MOJO_EVENT.memory:
+                this.currentMemoryMetric = this.consumeVarInt();
+                break;
+            case MOJO_EVENT.string: {
+                const k = this.consumeVarInt();
+                const v = this.consumeString();
+                this.stringRefs.set(`${this.currentPid}:${k}`, v);
+                break;
+            }
+            default:
+                throw new Error("Unknown MOJO event");
+        }
+    }
+
+    push(chunk: Buffer): void {
+        this.pending = Buffer.concat([this.pending.slice(this.offset), chunk]);
+        this.offset = 0;
+
+        if (this.version === null) {
+            const checkpoint = this.offset;
+            try {
+                this.consumeHeader();
+            } catch (e) {
+                if (e instanceof IteratorDone) {
+                    this.offset = checkpoint;
+                    return;
+                }
+                throw e;
+            }
+        }
+
+        while (true) {
+            const checkpoint = this.offset;
+            try {
+                this.processOneEvent();
+            } catch (e) {
+                if (e instanceof IteratorDone) {
+                    this.offset = checkpoint;
+                    break;
+                }
+                throw e;
+            }
+        }
+    }
+
+    finalize(): void {
+        if (this.currentPid !== null) {
+            this.stats.update(
+                Number(this.currentPid),
+                `${this.currentIid}:${this.currentTid}`,
+                this.currentStack,
+                Number(this.mode === "memory" ? this.currentMemoryMetric! : this.currentTimeMetric!),
+            );
+        }
+    }
+}

--- a/src/utils/versionCheck.ts
+++ b/src/utils/versionCheck.ts
@@ -12,7 +12,7 @@ export class AustinVersionError extends Error {
 
 export function checkAustinVersion(austinPath: string): Promise<void> {
     return new Promise((resolve, reject) => {
-        execFile(austinPath, ["--version"], (err, stdout, stderr) => {
+        execFile(austinPath, ["--version"], { shell: process.platform === "win32" }, (err, stdout, stderr) => {
             if (err) {
                 reject(new Error(`Failed to run '${austinPath} --version': ${err.message}`));
                 return;

--- a/src/utils/versionCheck.ts
+++ b/src/utils/versionCheck.ts
@@ -1,0 +1,34 @@
+import { execFile } from "child_process";
+
+
+const MIN_MAJOR = 4;
+
+export class AustinVersionError extends Error {
+    constructor(public readonly version: string) {
+        super(`Unsupported Austin version: ${version}. Please upgrade to ${MIN_MAJOR}.0.0 or newer.`);
+    }
+}
+
+
+export function checkAustinVersion(austinPath: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+        execFile(austinPath, ["--version"], (err, stdout, stderr) => {
+            if (err) {
+                reject(new Error(`Failed to run '${austinPath} --version': ${err.message}`));
+                return;
+            }
+            const output = (stdout || stderr).trim();
+            const match = output.match(/(\d+)\.(\d+)\.(\d+)/);
+            if (!match) {
+                reject(new Error(`Could not parse Austin version from: '${output}'`));
+                return;
+            }
+            const major = parseInt(match[1], 10);
+            if (major < MIN_MAJOR) {
+                reject(new AustinVersionError(match[0]));
+                return;
+            }
+            resolve();
+        });
+    });
+}


### PR DESCRIPTION
The Austin profile command now streams data live to the flame graph, top, and call stack views as samples arrive, rather than waiting for the process to finish.

- Add StreamingMojoParser: incremental MOJO binary parser that processes complete events from each stdout chunk and buffers any partial trailing event for the next chunk
- AustinStats gains begin()/refresh() for live sessions; raw metric accumulation is separated from normalised display values so refresh() can be called repeatedly without precision loss
- Executor feeds stdout chunks directly to StreamingMojoParser and fires a 1 s throttled refresh interval; final refresh + gutter decorations run on process exit
- Drop -b / binaryMode: Austin 4 always outputs MOJO binary on stdout; readFromBuffer() now auto-detects format from the MOJ magic header
- Fix CPU time flag: -s → -c (Austin 4 renamed the option)
- Fix mode not picked up: capture mode in task definition at build time and persist status-bar settings with ConfigurationTarget.Global so they are readable regardless of workspace context
- Add version check: profileScript() now runs austin --version before launching and shows an error if the version is older than 4.0.0
- Show a completion notification with the script's workspace-relative path when profiling finishes, and an error notification on non-zero exit

Resolves #30 