### PR TITLE
feat: attach to process, pause/resume, and UX improvements

### DIFF
--- a/media/callstack.js
+++ b/media/callstack.js
@@ -3,6 +3,7 @@
 
     let idCounter = 0;
     let expanded = new Set();
+    let expandedPaths = new Set();
     let treeData = null;
     let sortCol = 'own';
     let sortAsc = false;
@@ -14,6 +15,7 @@
         const msg = event.data;
         if (msg.loading) {
             treeData = null;
+            expandedPaths.clear();
             render();
             loading.classList.add('active');
         } else if (msg.tree !== undefined) {
@@ -49,6 +51,22 @@
         for (const node of sorted(treeData)) {
             appendNode(tbody, node, null, 0);
         }
+
+        restoreExpanded();
+    }
+
+    function restoreExpanded() {
+        if (expandedPaths.size === 0) { return; }
+        document.querySelectorAll('tr[data-expandable][data-path-key]').forEach(tr => {
+            const pk = tr.dataset.pathKey;
+            if (!pk || !expandedPaths.has(pk)) { return; }
+            const rowId = tr.dataset.rowId;
+            document.querySelectorAll(`tr[data-parent-id="${rowId}"]`).forEach(child => {
+                child.style.display = '';
+            });
+            expanded.add(rowId);
+            tr.dataset.open = '1';
+        });
     }
 
     function sorted(nodes) {
@@ -112,7 +130,10 @@
         if (isExpanded) {
             collapseDescendants(rowId);
             expanded.delete(rowId);
-            if (row) { delete row.dataset.open; }
+            if (row) {
+                delete row.dataset.open;
+                if (row.dataset.pathKey) { expandedPaths.delete(row.dataset.pathKey); }
+            }
         } else {
             if (row && row.dataset.childrenPending) {
                 // Children not yet loaded — request from extension
@@ -123,7 +144,10 @@
                 tr.style.display = '';
             });
             expanded.add(rowId);
-            if (row) { row.dataset.open = '1'; }
+            if (row) {
+                row.dataset.open = '1';
+                if (row.dataset.pathKey) { expandedPaths.add(row.dataset.pathKey); }
+            }
         }
     }
 
@@ -136,6 +160,7 @@
                 expanded.delete(childId);
                 delete tr.dataset.open;
             }
+            if (tr.dataset.pathKey) { expandedPaths.delete(tr.dataset.pathKey); }
         });
     }
 
@@ -168,6 +193,7 @@
         });
         expanded.add(parentId);
         parentRow.dataset.open = '1';
+        expandedPaths.add(parentPathKey);
     }
 
     function insertNodeBefore(tbody, refNode, node, parentId, level) {

--- a/media/flamegraph.js
+++ b/media/flamegraph.js
@@ -1,7 +1,7 @@
 // @ts-check
 (function () {
     // @ts-ignore
-    const vscode = acquireVsCodeApi();
+    const vscode = window.vscode = acquireVsCodeApi();
 
     // ── Utilities (loaded from flamegraph-utils.js) ───────────────────────────
     // @ts-ignore

--- a/media/top.js
+++ b/media/top.js
@@ -6,6 +6,7 @@
     let sortAsc = false;
     let filterTerm = '';
     let expanded = new Set();
+    let expandedKeys = new Set();
     let idCounter = 0;
 
     const loading     = document.getElementById('loading');
@@ -19,6 +20,7 @@
             filterTerm = '';
             filterInput.value = '';
             filterClear.classList.remove('visible');
+            expandedKeys.clear();
             render();
             loading.classList.add('active');
         } else if (message.top !== undefined) {
@@ -69,6 +71,22 @@
             appendTopRow(tbody, item, rowId);
             appendCallerRows(tbody, item.callers, rowId, 1);
         }
+
+        restoreExpanded();
+    }
+
+    function restoreExpanded() {
+        if (expandedKeys.size === 0) { return; }
+        document.querySelectorAll('tr[data-expandable][data-caller-key]').forEach(tr => {
+            const k = tr.dataset.callerKey;
+            if (!k || !expandedKeys.has(k)) { return; }
+            const rowId = tr.dataset.rowId;
+            document.querySelectorAll(`tr[data-parent-id="${rowId}"]`).forEach(child => {
+                child.style.display = '';
+            });
+            expanded.add(rowId);
+            tr.dataset.open = '1';
+        });
     }
 
     function appendTopRow(tbody, item, rowId) {
@@ -131,7 +149,10 @@
         if (isExpanded) {
             collapseDescendants(rowId);
             expanded.delete(rowId);
-            if (row) { delete row.dataset.open; }
+            if (row) {
+                delete row.dataset.open;
+                if (row.dataset.callerKey) { expandedKeys.delete(row.dataset.callerKey); }
+            }
         } else {
             if (row && row.dataset.callersPending) {
                 vscode.postMessage({ requestCallers: {
@@ -145,7 +166,10 @@
                 tr.style.display = '';
             });
             expanded.add(rowId);
-            if (row) { row.dataset.open = '1'; }
+            if (row) {
+                row.dataset.open = '1';
+                if (row.dataset.callerKey) { expandedKeys.add(row.dataset.callerKey); }
+            }
         }
     }
 
@@ -185,6 +209,7 @@
         });
         expanded.add(rowId);
         parentRow.dataset.open = '1';
+        if (parentRow.dataset.callerKey) { expandedKeys.add(parentRow.dataset.callerKey); }
     }
 
     function insertCallerBefore(tbody, refNode, caller, parentId, level) {
@@ -228,6 +253,7 @@
                 expanded.delete(childId);
                 delete tr.dataset.open;
             }
+            if (tr.dataset.callerKey) { expandedKeys.delete(tr.dataset.callerKey); }
         });
     }
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "icon": "art/logo.png",
   "activationEvents": [
     "onCommand:austin-vscode.profile",
+    "onCommand:austin-vscode.attach",
     "onCommand:austin-vscode.load",
     "onStartupFinished",
     "onView:austin-vscode.flame-graph",
@@ -120,8 +121,20 @@
         "title": "Profile with Austin"
       },
       {
+        "command": "austin-vscode.attach",
+        "title": "Attach Austin to Process"
+      },
+      {
+        "command": "austin-vscode.detach",
+        "title": "Detach Austin from Process"
+      },
+      {
         "command": "austin-vscode.load",
         "title": "Load Austin Samples ..."
+      },
+      {
+        "command": "austin-vscode.togglePause",
+        "title": "Pause/Resume Austin UI Refreshes"
       }
     ],
     "keybindings": [
@@ -135,6 +148,11 @@
         "key": "shift+f5",
         "mac": "shift+f5",
         "when": "!inDebugMode && editorLangId == python"
+      },
+      {
+        "command": "austin-vscode.attach",
+        "key": "ctrl+shift+f5",
+        "mac": "ctrl+shift+f5"
       }
     ],
     "taskDefinitions": [
@@ -181,6 +199,10 @@
           "envFile": {
             "type": "string",
             "description": "Path to a .env file to load environment variables from"
+          },
+          "pid": {
+            "type": "number",
+            "description": "PID of a running Python process to attach to (mutually exclusive with file)"
           }
         }
       }

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -8,11 +8,26 @@ import { AustinVersionError, checkAustinVersion } from './utils/versionCheck';
 
 
 export class AustinController {
+    private _currentExecution: vscode.TaskExecution | undefined;
+
     public constructor(
         private stats: AustinStats,
         private provider: AustinProfileTaskProvider,
         private output: vscode.OutputChannel,
     ) { }
+
+    private async checkVersion(): Promise<boolean> {
+        try {
+            await checkAustinVersion(AustinRuntimeSettings.getPath());
+            return true;
+        } catch (e) {
+            const message = (e instanceof AustinVersionError)
+                ? e.message
+                : `Could not determine Austin version: ${(e instanceof Error) ? e.message : e}`;
+            vscode.window.showErrorMessage(message);
+            return false;
+        }
+    }
 
     public async profileScript() {
         const currentUri = vscode.window.activeTextEditor?.document.uri;
@@ -20,23 +35,50 @@ export class AustinController {
             throw Error("Python extension not available");
         }
 
-        try {
-            await checkAustinVersion(AustinRuntimeSettings.getPath());
-        } catch (e) {
-            const message = (e instanceof AustinVersionError)
-                ? e.message
-                : `Could not determine Austin version: ${(e instanceof Error) ? e.message : e}`;
-            vscode.window.showErrorMessage(message);
-            return;
-        }
+        if (!await this.checkVersion()) { return; }
 
         if (currentUri?.scheme === "file") {
             let task = this.provider.buildTaskFromUri(currentUri);
-            await vscode.tasks.executeTask(task);
+            this._currentExecution = await vscode.tasks.executeTask(task);
         }
         else {
             vscode.window.showErrorMessage("Please save the file to disk first!");
         }
+    }
+
+    public async attachProcess() {
+        if (!await this.checkVersion()) { return; }
+
+        const pidStr = await vscode.window.showInputBox({
+            prompt: "Enter the PID of the Python process to attach to",
+            placeHolder: "e.g. 12345",
+            validateInput: (value) => {
+                if (!/^\d+$/.test(value) || parseInt(value) <= 0) {
+                    return "Please enter a valid process ID (positive integer).";
+                }
+            },
+        });
+
+        if (!pidStr) { return; }
+
+        const pid = parseInt(pidStr);
+        const task = this.provider.buildTaskFromPid(pid);
+        this._currentExecution = await vscode.tasks.executeTask(task);
+    }
+
+    public detach() {
+        this._currentExecution?.terminate();
+        this._currentExecution = undefined;
+    }
+
+    public clearCurrentExecution(execution: vscode.TaskExecution) {
+        if (this._currentExecution === execution) {
+            this._currentExecution = undefined;
+        }
+    }
+
+    public get isRunning(): boolean {
+        return this._currentExecution !== undefined;
     }
 
     public openSampleFile() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { clearDecorations, formatInterval } from './view';
+import { clearDecorations, formatInterval, setLinesHeat } from './view';
 import { FlameGraphViewProvider } from './providers/flamegraph';
 import { AustinController } from './controller';
 import { AustinStats } from './model';
@@ -15,9 +15,20 @@ export function activate(context: vscode.ExtensionContext) {
 		clearDecorations();
 	});
 
+	const stats = new AustinStats();
+
+	context.subscriptions.push(
+		vscode.window.onDidChangeActiveTextEditor((editor) => {
+			if (editor?.document.uri.scheme === "file") {
+				const lines = stats.locationMap.get(editor.document.uri.fsPath);
+				if (lines) { setLinesHeat(lines, stats); }
+				else { clearDecorations(); }
+			}
+		})
+	);
+
 	const output = vscode.window.createOutputChannel("Austin");
 
-	const stats = new AustinStats();
 	const austinProfileProvider = new AustinProfileTaskProvider(stats, output);
 	const controller = new AustinController(stats, austinProfileProvider, output);
 
@@ -31,6 +42,13 @@ export function activate(context: vscode.ExtensionContext) {
 	stats.registerAfterCallback((stats) => flameGraphViewProvider.refresh(stats));
 	stats.registerAfterCallback((stats) => topProvider.refresh(stats));
 	stats.registerAfterCallback((stats) => callStackProvider.refresh(stats));
+	stats.registerAfterCallback((stats) => {
+		const editor = vscode.window.activeTextEditor;
+		if (editor?.document.uri.scheme === "file") {
+			const lines = stats.locationMap.get(editor.document.uri.fsPath);
+			if (lines) { setLinesHeat(lines, stats); }
+		}
+	});
 
 	flameGraphViewProvider.onFrameSelected((pathKey) => callStackProvider.focusPath(pathKey));
 	callStackProvider.onFrameSelected((pathKey) => flameGraphViewProvider.focusFrame(pathKey));
@@ -61,6 +79,12 @@ export function activate(context: vscode.ExtensionContext) {
 	);
 
 	context.subscriptions.push(
+		vscode.commands.registerCommand('austin-vscode.attach', () => {
+			controller.attachProcess();
+		})
+	);
+
+	context.subscriptions.push(
 		vscode.commands.registerCommand('austin-vscode.load', () => {
 			controller.openSampleFile();
 		})
@@ -69,6 +93,63 @@ export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(
 		vscode.commands.registerCommand('austin-vscode.openSourceAtLine', (module: string, line: number) => {
 			controller.openSourceFileAtLine(module, line);
+		})
+	);
+
+	// ---- Detach status bar item (shown while a profiling session is active) ----
+	const detachStatusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 200);
+	detachStatusBarItem.command = "austin-vscode.detach";
+	detachStatusBarItem.text = "$(debug-disconnect) Detach Austin";
+	detachStatusBarItem.tooltip = "Stop Austin and detach from the process";
+	detachStatusBarItem.backgroundColor = new vscode.ThemeColor("statusBarItem.warningBackground");
+
+	context.subscriptions.push(
+		vscode.commands.registerCommand('austin-vscode.detach', () => {
+			controller.detach();
+		})
+	);
+
+	// ---- Pause/resume status bar item ----
+	const pauseStatusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 199);
+	pauseStatusBarItem.command = "austin-vscode.togglePause";
+	pauseStatusBarItem.text = "$(debug-pause) Pause";
+	pauseStatusBarItem.tooltip = "Pause UI refreshes (data collection continues)";
+
+	context.subscriptions.push(
+		vscode.commands.registerCommand('austin-vscode.togglePause', () => {
+			stats.paused = !stats.paused;
+			if (stats.paused) {
+				pauseStatusBarItem.text = "$(debug-continue) Resume";
+				pauseStatusBarItem.tooltip = "Resume UI refreshes";
+			} else {
+				pauseStatusBarItem.text = "$(debug-pause) Pause";
+				pauseStatusBarItem.tooltip = "Pause UI refreshes (data collection continues)";
+				stats.refresh();
+			}
+		})
+	);
+
+	context.subscriptions.push(
+		vscode.tasks.onDidStartTask((e) => {
+			if (e.execution.task.definition.type === "austin") {
+				detachStatusBarItem.show();
+				pauseStatusBarItem.show();
+				flameGraphViewProvider.showDetachButton();
+			}
+		})
+	);
+
+	context.subscriptions.push(
+		vscode.tasks.onDidEndTask((e) => {
+			if (e.execution.task.definition.type === "austin") {
+				controller.clearCurrentExecution(e.execution);
+				detachStatusBarItem.hide();
+				pauseStatusBarItem.hide();
+				stats.paused = false;
+				pauseStatusBarItem.text = "$(debug-pause) Pause";
+				pauseStatusBarItem.tooltip = "Pause UI refreshes (data collection continues)";
+				flameGraphViewProvider.showOpenButton();
+			}
 		})
 	);
 

--- a/src/model.ts
+++ b/src/model.ts
@@ -72,6 +72,7 @@ export interface AustinStats {
 
 export class AustinStats implements AustinStats {
 
+    public paused: boolean = false;
     private _beforeCbs: (() => void)[];
     private _afterCbs: ((stats: AustinStats) => void)[];
 

--- a/src/providers/executor.ts
+++ b/src/providers/executor.ts
@@ -31,6 +31,8 @@ function resolveArgs(args: string[]): string[] {
 
 export class AustinCommandExecutor implements vscode.Pseudoterminal {
   private austinProcess: ChildProcess | undefined;
+  private _killed: boolean = false;
+  private _processExited: boolean = false;
   result: number = 0;
 
   constructor(
@@ -91,15 +93,24 @@ export class AustinCommandExecutor implements vscode.Pseudoterminal {
 
       let lastTotal = 0;
       const refreshInterval = setInterval(() => {
-        if (this.stats.overallTotal > lastTotal) {
+        if (!this.stats.paused && this.stats.overallTotal > lastTotal) {
           lastTotal = this.stats.overallTotal;
           this.stats.refresh();
         }
       }, 1000);
 
       this.austinProcess.on("close", (code) => {
+        this._processExited = true;
         clearInterval(refreshInterval);
-        if (code !== 0) {
+        if (this._killed) {
+          // Intentional detach: we sent a kill signal before the process exited
+          this.writeEmitter.fire("Austin detached.\r\n");
+          this.closeEmitter.fire(0);
+          const label = fileName ?? "process";
+          vscode.window.showInformationMessage(`Austin detached from ${label}.`);
+          parser.finalize();
+          this.stats.refresh();
+        } else if (code !== 0) {
           this.writeEmitter.fire(`austin process exited with code ${code}\r\n`);
           this.result = code!;
           this.closeEmitter.fire(code!);
@@ -127,6 +138,9 @@ export class AustinCommandExecutor implements vscode.Pseudoterminal {
   close(): void {
     // The terminal has been closed. Shutdown the build.
     if (this.austinProcess && !this.austinProcess.killed) {
+      if (!this._processExited) {
+        this._killed = true;
+      }
       this.austinProcess.kill();
     }
   }

--- a/src/providers/flamegraph.ts
+++ b/src/providers/flamegraph.ts
@@ -1,5 +1,4 @@
 import * as vscode from 'vscode';
-import { setLinesHeat } from '../view';
 import { AustinStats } from '../model';
 
 
@@ -14,6 +13,8 @@ export class FlameGraphViewProvider implements vscode.WebviewViewProvider {
     private _stats: AustinStats | null = null;
     private _initialized: boolean = false;
     private _onFrameSelected?: (pathKey: string) => void;
+    private _sessionActive: boolean = false;
+    private _flameHtmlSet: boolean = false;
 
     constructor(
         private readonly _extensionUri: vscode.Uri,
@@ -26,6 +27,8 @@ export class FlameGraphViewProvider implements vscode.WebviewViewProvider {
         _token: vscode.CancellationToken,
     ) {
         this._view = webviewView;
+        this._initialized = false;
+        this._flameHtmlSet = false;
 
         webviewView.webview.options = {
             // Allow scripts in the webview
@@ -47,6 +50,11 @@ export class FlameGraphViewProvider implements vscode.WebviewViewProvider {
 
             if (data === "open") {
                 vscode.commands.executeCommand('austin-vscode.load');
+                return;
+            }
+
+            if (data === "detach") {
+                vscode.commands.executeCommand('austin-vscode.detach');
                 return;
             }
 
@@ -107,25 +115,33 @@ export class FlameGraphViewProvider implements vscode.WebviewViewProvider {
         this._view?.webview.postMessage({ focus: pathKey });
     }
 
+    public showDetachButton() {
+        this._sessionActive = true;
+        if (this._initialized) {
+            this._view?.webview.postMessage('showDetach');
+        }
+    }
+
+    public showOpenButton() {
+        this._sessionActive = false;
+        if (this._initialized) {
+            this._view?.webview.postMessage('showOpen');
+        }
+    }
+
     public refresh(stats: AustinStats) {
         this._stats = stats;
         if (this._view) {
-            this._setFlameGraphHtml();
-            this._view.show?.(true);
+            if (!this._flameHtmlSet) {
+                this._setFlameGraphHtml();
+                this._flameHtmlSet = true;
+            }
 
             if (this._initialized) {
                 this._view.webview.postMessage({
                     "meta": { "mode": stats.metadata.get("mode") },
                     "hierarchy": stats.hierarchy,
                 });
-            }
-            // this._source = austinFile;
-        }
-        const currentUri = vscode.window.activeTextEditor?.document.uri;
-        if (currentUri?.scheme === "file") {
-            const lines = stats.locationMap.get(currentUri.fsPath);
-            if (lines) {
-                setLinesHeat(lines, stats);
             }
         }
     }
@@ -141,18 +157,35 @@ export class FlameGraphViewProvider implements vscode.WebviewViewProvider {
         const austinCssUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, 'media', 'austin.css'));
         const austinLogoUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, 'media', 'austin-light.svg'));
 
+        const btnText = this._sessionActive ? 'Detach' : 'Open';
+        const btnOnclick = this._sessionActive ? 'onDetach()' : 'onOpen()';
+
         webview.html = `<!DOCTYPE html>
 			<html lang="en">
             <head>
                 <link rel="stylesheet" type="text/css" href="${austinCssUri}">
             </head>
             <body class="logo">
-                <div id="header"><img src="${austinLogoUri}" /><span class="vc" id="mode"></span><input id="search-box" type="text" placeholder="Search…" /><button id="header-open" onclick="onOpen()">Open</button></div>
+                <div id="header"><img src="${austinLogoUri}" /><span class="vc" id="mode"></span><input id="search-box" type="text" placeholder="Search…" /><button id="header-open" onclick="${btnOnclick}">${btnText}</button></div>
                 <div id="chart"></div>
                 <div id="footer"></div>
 
                 <script type="text/javascript" src="${flameGraphUtilsUri}"></script>
                 <script type="text/javascript" src="${flameGraphScriptUri}"></script>
+                <script>
+                function onOpen() { window.vscode.postMessage("open"); }
+                function onDetach() { window.vscode.postMessage("detach"); }
+                window.addEventListener('message', function(e) {
+                    var btn = document.getElementById('header-open');
+                    if (e.data === 'showDetach') {
+                        btn.textContent = 'Detach';
+                        btn.onclick = onDetach;
+                    } else if (e.data === 'showOpen') {
+                        btn.textContent = 'Open';
+                        btn.onclick = onOpen;
+                    }
+                });
+                </script>
             </body>
 			</html>`;
     }
@@ -214,7 +247,7 @@ export class FlameGraphViewProvider implements vscode.WebviewViewProvider {
 
                 <script>
                 const vscode = acquireVsCodeApi();
-                
+
                 function onOpen() {
                     vscode.postMessage("open");;
                 }

--- a/src/providers/task.ts
+++ b/src/providers/task.ts
@@ -35,14 +35,30 @@ export class AustinProfileTaskProvider implements vscode.TaskProvider {
     );
   }
 
+  public buildTaskFromPid(pid: number) {
+    return this.buildTask(
+      {
+        pid,
+        type: "austin",
+        command: platform() === "darwin" ? ["sudo"] : undefined,
+        mode: AustinRuntimeSettings.getMode(),
+      },
+      vscode.TaskScope.Workspace,
+    );
+  }
+
   public buildTask(
     definition: AustinProfileTaskDefinition,
     scope: vscode.WorkspaceFolder | vscode.TaskScope,
   ): vscode.Task {
+    const taskName = definition.pid !== undefined
+      ? `attach to PID ${definition.pid}`
+      : definition.file ? `profile ${definition.file}` : "profile";
+
     return new vscode.Task(
       definition,
       scope,
-      definition.file ? `profile ${definition.file}` : "profile", // TODO: add better logging
+      taskName,
       "austin",
       new vscode.CustomExecution(async (): Promise<vscode.Pseudoterminal> => {
         let cwd: string | undefined = undefined;
@@ -78,14 +94,19 @@ export class AustinProfileTaskProvider implements vscode.TaskProvider {
           definition.interval,
           definition.mode,
           definition.envFile,
+          definition.pid,
         );
+
+        const fileName = definition.pid !== undefined
+          ? `PID ${definition.pid}`
+          : resolvedPath?.fsPath;
 
         return new AustinCommandExecutor(
           command,
           cwd!,
           this.output,
           this.stats,
-          resolvedPath?.fsPath,
+          fileName,
         );
       })
     );
@@ -113,12 +134,12 @@ interface AustinProfileTaskDefinition extends vscode.TaskDefinition {
    */
   args?: string[];
 
-  /** 
+  /**
    * Polling interval
    */
   interval?: number;
 
-  /** 
+  /**
    * Mode, either "Wall time" or "CPU time"
    */
   mode?: AustinMode;
@@ -137,4 +158,9 @@ interface AustinProfileTaskDefinition extends vscode.TaskDefinition {
    * Optional environment file to source before running austin
    */
   envFile?: string;
+
+  /**
+   * PID of a running Python process to attach to
+   */
+  pid?: number;
 }

--- a/src/test/suite/commandFactory.test.ts
+++ b/src/test/suite/commandFactory.test.ts
@@ -1,0 +1,102 @@
+import * as assert from 'assert';
+import { getAustinCommand } from '../../utils/commandFactory';
+// Side-effect imports required by model internals used by settings
+import '../../stringExtension';
+import '../../mapExtension';
+
+
+// The vscode-mock returns all config values as their supplied default, so
+// AustinRuntimeSettings uses its own DEFAULT_* constants:
+//   path     → "austin"
+//   interval → 100
+//   mode     → AustinMode.WallTime ("Wall time") — no extra flag
+
+
+// ---------------------------------------------------------------------------
+// getAustinCommand — pid support
+// ---------------------------------------------------------------------------
+suite('getAustinCommand — pid support', () => {
+
+    test('adds -p flag with the given pid', () => {
+        const { args } = getAustinCommand(undefined, undefined, undefined, undefined, undefined, undefined, undefined, 12345);
+        const pidIdx = args.indexOf('-p');
+        assert.ok(pidIdx >= 0, 'args should contain -p');
+        assert.strictEqual(args[pidIdx + 1], '12345');
+    });
+
+    test('does not include a python interpreter when pid is given', () => {
+        // With pid, getConfiguredInterpreter() must NOT be called (it would throw
+        // because ms-python is unavailable in the test environment).
+        const { args } = getAustinCommand(undefined, undefined, undefined, undefined, undefined, undefined, undefined, 99);
+        // The only positional argument after --pipe and any mode flag should be
+        // the -p / pid pair — no interpreter string anywhere.
+        const pipeIdx = args.indexOf('--pipe');
+        const argsAfterPipe = args.slice(pipeIdx + 1);
+        assert.deepStrictEqual(argsAfterPipe, ['-p', '99']);
+    });
+
+    test('does not include pythonArgs when pid is given', () => {
+        const { args } = getAustinCommand(
+            '/some/script.py',          // pythonFile — ignored because pid wins
+            undefined,
+            ['--my-arg', 'value'],      // pythonArgs — should not appear
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            42,
+        );
+        assert.ok(!args.includes('--my-arg'), 'pythonArgs should not be in the command');
+        assert.ok(!args.includes('value'));
+    });
+
+    test('pid takes precedence over pythonFile', () => {
+        const { args } = getAustinCommand(
+            '/some/script.py',
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            7,
+        );
+        assert.ok(!args.includes('/some/script.py'), 'pythonFile should not appear when pid is given');
+        assert.ok(args.includes('-p'));
+    });
+
+    test('standard flags (-i, --pipe) still appear before -p', () => {
+        const { args } = getAustinCommand(undefined, undefined, undefined, undefined, undefined, undefined, undefined, 1);
+        assert.ok(args.includes('-i'), 'interval flag should be present');
+        assert.ok(args.includes('--pipe'), '--pipe flag should be present');
+        const pFlag = args.indexOf('-p');
+        const pipeFlag = args.indexOf('--pipe');
+        assert.ok(pipeFlag < pFlag, '--pipe should come before -p');
+    });
+
+    test('works with a command prefix such as sudo', () => {
+        const { cmd, args } = getAustinCommand(
+            undefined,
+            ['sudo'],                   // command prefix
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            5678,
+        );
+        assert.strictEqual(cmd, 'sudo');
+        assert.ok(args.includes('austin'), 'austin path should be in args when using a command prefix');
+        assert.ok(args.includes('-p'));
+        assert.strictEqual(args[args.indexOf('-p') + 1], '5678');
+    });
+
+    test('envFile is threaded through unchanged', () => {
+        const { envFile } = getAustinCommand(
+            undefined, undefined, undefined, undefined, undefined, undefined,
+            '/path/to/.env',
+            1,
+        );
+        assert.strictEqual(envFile, '/path/to/.env');
+    });
+});

--- a/src/test/suite/model.test.ts
+++ b/src/test/suite/model.test.ts
@@ -337,3 +337,48 @@ suite('AustinStats.begin', () => {
         assert.strictEqual(called, 1);
     });
 });
+
+
+// ---------------------------------------------------------------------------
+// AustinStats — paused flag
+// ---------------------------------------------------------------------------
+suite('AustinStats — paused flag', () => {
+
+    test('paused defaults to false', () => {
+        const stats = new AustinStats();
+        assert.strictEqual(stats.paused, false);
+    });
+
+    test('paused can be set to true', () => {
+        const stats = new AustinStats();
+        stats.paused = true;
+        assert.strictEqual(stats.paused, true);
+    });
+
+    test('paused can be toggled back to false', () => {
+        const stats = new AustinStats();
+        stats.paused = true;
+        stats.paused = false;
+        assert.strictEqual(stats.paused, false);
+    });
+
+    test('refresh() still fires after-callbacks regardless of paused (paused is checked by the caller)', () => {
+        // The paused flag is intentionally not checked inside refresh() itself —
+        // the executor's setInterval is responsible for skipping the call.
+        // This test documents that contract.
+        const stats = new AustinStats();
+        let called = 0;
+        stats.registerAfterCallback(() => { called++; });
+        stats.paused = true;
+        stats.update(1, 'T1', [], 100);
+        stats.refresh();
+        assert.strictEqual(called, 1, 'refresh() fires callbacks even when paused');
+    });
+
+    test('begin() does not reset paused', () => {
+        const stats = new AustinStats();
+        stats.paused = true;
+        stats.begin('new.austin');
+        assert.strictEqual(stats.paused, true);
+    });
+});

--- a/src/test/suite/view.test.ts
+++ b/src/test/suite/view.test.ts
@@ -1,5 +1,8 @@
 import * as assert from 'assert';
-import { computeGutterMetrics, formatInterval, formatMemory, formatTime, modeColors, statColor } from '../../view';
+import { computeGutterMetrics, formatInterval, formatMemory, formatTime, modeColors, setLinesHeat, statColor } from '../../view';
+import { AustinStats, FrameObject } from '../../model';
+import '../../stringExtension';
+import '../../mapExtension';
 
 suite('formatTime', () => {
 
@@ -178,5 +181,106 @@ suite('computeGutterMetrics', () => {
         const m = computeGutterMetrics(5);
         assert.ok(m.labelX1 > m.col1X + m.barTrackW);
         assert.ok(m.labelX2 > m.col2X + m.barTrackW);
+    });
+});
+
+
+// ---------------------------------------------------------------------------
+// setLinesHeat — dispose ordering (no-flicker guarantee)
+//
+// Old behaviour: clearDecorations() (dispose all) → create new decorators
+//                Results in a brief flash with no decorations visible.
+//
+// New behaviour: save old decorators → create new → dispose old
+//                New decorations are applied before old ones disappear.
+// ---------------------------------------------------------------------------
+suite('setLinesHeat — dispose ordering', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const vscodeWindow = (require('vscode') as { window: Record<string, unknown> }).window;
+
+    let events: string[] = [];
+    let typeIdCounter = 0;
+    let savedCreateDeco: unknown;
+    let savedEditorDescriptor: PropertyDescriptor | undefined;
+
+    const mockRange = { start: {}, end: {} };
+    const mockEditor = {
+        document: {
+            lineCount: 20,
+            lineAt: (_i: number) => ({ range: mockRange, text: 'pass' }),
+        },
+        setDecorations: (_type: { id: string }, _ranges: unknown[]) => {
+            events.push(`set:${_type.id}`);
+        },
+    };
+
+    setup(() => {
+        events = [];
+        typeIdCounter = 0;
+        savedCreateDeco = vscodeWindow.createTextEditorDecorationType;
+        savedEditorDescriptor = Object.getOwnPropertyDescriptor(vscodeWindow, 'activeTextEditor');
+
+        vscodeWindow.createTextEditorDecorationType = (_opts: unknown) => {
+            const id = String(typeIdCounter++);
+            return { id, dispose: () => events.push(`dispose:${id}`) };
+        };
+        Object.defineProperty(vscodeWindow, 'activeTextEditor', {
+            get: () => mockEditor,
+            configurable: true,
+        });
+    });
+
+    teardown(() => {
+        vscodeWindow.createTextEditorDecorationType = savedCreateDeco;
+        if (savedEditorDescriptor) {
+            Object.defineProperty(vscodeWindow, 'activeTextEditor', savedEditorDescriptor);
+        }
+    });
+
+    function makeStats(): [AustinStats, Map<string, [FrameObject, number, number]>] {
+        const frame: FrameObject = { module: '/tmp/test.py', scope: 'foo', line: 5 };
+        const stats = new AustinStats();
+        stats.begin('/tmp/test.py');
+        stats.update(0, '0', [frame], 1000);
+        stats.refresh();
+        const locations = stats.locationMap.get('/tmp/test.py')!;
+        return [stats, locations];
+    }
+
+    test('first call creates decorators and nothing is disposed', () => {
+        const [stats, locations] = makeStats();
+        setLinesHeat(locations, stats);
+
+        assert.ok(events.some(e => e.startsWith('set:')), 'decorators should be applied');
+        assert.ok(!events.some(e => e.startsWith('dispose:')), 'nothing to dispose on first call');
+    });
+
+    test('second call disposes old decorators after applying new ones', () => {
+        const [stats, locations] = makeStats();
+
+        setLinesHeat(locations, stats);
+        const firstCallTypeCount = typeIdCounter; // types 0 .. firstCallTypeCount-1
+
+        events = []; // reset — we only care about the second call's ordering
+        setLinesHeat(locations, stats);
+
+        const setEvents     = events.filter(e => e.startsWith('set:'));
+        const disposeEvents = events.filter(e => e.startsWith('dispose:'));
+
+        assert.ok(setEvents.length > 0, 'second call should create new decorators');
+        assert.ok(disposeEvents.length > 0, 'second call should dispose first-call decorators');
+
+        // All disposed IDs should belong to the first call
+        for (const ev of disposeEvents) {
+            const id = parseInt(ev.slice('dispose:'.length), 10);
+            assert.ok(id < firstCallTypeCount, `disposed id ${id} should be from first call`);
+        }
+
+        // Every dispose event must come after the last set event in the sequence
+        const lastSetIdx     = events.map((e, i) => e.startsWith('set:')     ? i : -1).reduce((a, b) => Math.max(a, b), -1);
+        const firstDisposeIdx = events.findIndex(e => e.startsWith('dispose:'));
+
+        assert.ok(firstDisposeIdx > lastSetIdx,
+            'all new setDecorations calls must precede disposal of old decorators');
     });
 });

--- a/src/utils/commandFactory.ts
+++ b/src/utils/commandFactory.ts
@@ -17,7 +17,8 @@ export function getAustinCommand(
     austinArgs: string[] | undefined = undefined,
     interval: number | undefined = undefined,
     mode: AustinMode | undefined = undefined,
-    envFile: string | undefined = undefined
+    envFile: string | undefined = undefined,
+    pid: number | undefined = undefined,
 ): AustinCommandArguments {
     const settings = AustinRuntimeSettings.get().settings;
     let _args: string[] = [];
@@ -38,11 +39,13 @@ export function getAustinCommand(
     if (_mode === AustinMode.CpuTime) { _args.push("-c"); }
     if (_mode === AustinMode.Memory) { _args.push("-m"); }
     if (austinArgs) { _args = _args.concat(austinArgs); }
-    if (pythonFile) {
+    if (pid !== undefined) {
+        _args.push("-p", `${pid}`);
+    } else if (pythonFile) {
         _args.push(getConfiguredInterpreter());
         _args.push(pythonFile);
+        if (pythonArgs) { _args = _args.concat(pythonArgs); }
     }
-    if (pythonArgs) { _args = _args.concat(pythonArgs); }
 
     return {
         cmd: cmd,

--- a/src/view.ts
+++ b/src/view.ts
@@ -374,7 +374,8 @@ function setLinesStats(lineStats: Map<number, [number, number]>, overallTotal: n
 }
 
 export function setLinesHeat(locations: Map<string, [FrameObject, number, number]>, stats: AustinStats) {
-    clearDecorations();
+    const oldDecorators = decorators;
+    decorators = [];
 
     const overallTotal = stats.overallTotal;
     const localTotal = Array.from(locations.values()).map(v => v[1]).reduce((s, c) => s + c, 0);
@@ -398,6 +399,8 @@ export function setLinesHeat(locations: Map<string, [FrameObject, number, number
     });
 
     setLinesStats(lineStats, overallTotal, localTotal, mode);
+
+    oldDecorators.forEach(d => d.dispose());
 }
 
 


### PR DESCRIPTION
New features
- Attach Austin to a running Python process by PID via the new "Attach Austin to Process" command (Ctrl+Shift+F5).  Attaching requires elevated privileges (sudo on macOS and Linux) which is handled automatically.
- Detach command: terminates the active profiling session cleanly and shows a success notification instead of an error.  A "Detach Austin" status bar item appears while a session is live.
- Pause/Resume status bar item to suspend UI refreshes without stopping data collection, reducing visual noise when inspecting the views.

UI fixes
- Flamegraph header button toggles between "Open" and "Detach" for the active session; the vscode API reference is now exposed globally so the inline onclick handlers work correctly.
- Top and Call Stacks views preserve expanded rows across data refreshes (keyed on stable pathKey / callerKey) so the views no longer collapse on every update.
- Editor decorations (line heat) are updated on every stats refresh and when switching files, but without flickering: new decorations are applied before old ones are disposed.
- Flamegraph HTML is only generated once per view lifetime; subsequent refreshes use postMessage so the webview never reloads mid-session.

Bug fixes
- Detach detection now uses a _processExited flag to distinguish an intentional kill from a fast-failing process (e.g. exit code 241 from sudo on macOS), eliminating spurious error messages on detach.
- Added sudo for Linux when attaching by PID (ptrace on arbitrary processes requires elevated privileges even on Linux).

Tests
- getAustinCommand: 7 new tests covering pid support.
- AustinStats.paused: 5 new tests documenting the pause contract.
- setLinesHeat dispose ordering: 2 new tests asserting that new decorations are applied before old ones are disposed.