### PR TITLE
feat: live session UX improvements and attach mode fixes

### DIFF
--- a/media/austin.css
+++ b/media/austin.css
@@ -98,6 +98,15 @@ button {
     background: rgba(255, 255, 255, 0.1) !important;
 }
 
+@keyframes austin-live-pulse {
+    0%, 100% { opacity: 1; }
+    50%       { opacity: 0.35; }
+}
+
+#austin-logo.live {
+    animation: austin-live-pulse 1.8s ease-in-out infinite;
+}
+
 #chart {
     padding-top: 32px;
     padding-bottom: 36px;

--- a/media/callstack.js
+++ b/media/callstack.js
@@ -10,6 +10,7 @@
 
     const syncToggle = document.getElementById('sync-toggle');
     const loading = document.getElementById('loading');
+    const liveDot = document.getElementById('live-dot');
 
     window.addEventListener('message', event => {
         const msg = event.data;
@@ -26,6 +27,8 @@
             insertLazyChildren(msg.childrenFor, msg.children);
         } else if (msg.focus) {
             if (syncToggle.checked) { focusPath(msg.focus.pathKey); }
+        } else if (msg.live !== undefined) {
+            liveDot.classList.toggle('active', !!msg.live);
         }
     });
 

--- a/media/flamegraph.js
+++ b/media/flamegraph.js
@@ -312,10 +312,16 @@
         if (hierarchy.children) {
             for (const child of hierarchy.children) { addPathKeys(child, ''); }
         }
+        // Preserve zoom and search across live updates by re-finding the node
+        const prevZoomKey = zoomNode && zoomNode.data ? zoomNode.data.pathKey : null;
         rootNode = hierarchy;
-        zoomNode = null;
         hoveredFrame = null;
-        searchTerm = '';
+        if (prevZoomKey) {
+            zoomNode = findByPathKey(rootNode, prevZoomKey) || null;
+        } else {
+            zoomNode = null;
+            searchTerm = '';
+        }
         rebuildAndRender(false);
     }
 

--- a/media/top.js
+++ b/media/top.js
@@ -13,6 +13,8 @@
     const filterInput = document.getElementById('filter-input');
     const filterClear = document.getElementById('filter-clear');
 
+    const liveDot = document.getElementById('live-dot');
+
     window.addEventListener('message', event => {
         const message = event.data;
         if (message.loading) {
@@ -29,6 +31,8 @@
             render();
         } else if (message.callersFor !== undefined) {
             insertLazyCallers(message.callersFor, message.callers);
+        } else if (message.live !== undefined) {
+            liveDot.classList.toggle('active', !!message.live);
         }
     });
 

--- a/package.json
+++ b/package.json
@@ -58,6 +58,11 @@
           ],
           "default": "Wall time"
         },
+        "austin.children": {
+          "description": "Profile child processes as well (-C)",
+          "type": "boolean",
+          "default": false
+        },
         "austin.lineStats": {
           "description": "Line statistics",
           "type": "string",
@@ -135,6 +140,10 @@
       {
         "command": "austin-vscode.togglePause",
         "title": "Pause/Resume Austin UI Refreshes"
+      },
+      {
+        "command": "austin-vscode.toggleChildren",
+        "title": "Toggle Austin Children Profiling"
       }
     ],
     "keybindings": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -96,11 +96,10 @@ export function activate(context: vscode.ExtensionContext) {
 		})
 	);
 
-	// ---- Detach status bar item (shown while a profiling session is active) ----
+	// ---- Stop/detach status bar item (shown while a profiling session is active) ----
 	const detachStatusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 200);
 	detachStatusBarItem.command = "austin-vscode.detach";
-	detachStatusBarItem.text = "$(debug-disconnect) Detach Austin";
-	detachStatusBarItem.tooltip = "Stop Austin and detach from the process";
+	detachStatusBarItem.tooltip = "Stop Austin";
 	detachStatusBarItem.backgroundColor = new vscode.ThemeColor("statusBarItem.warningBackground");
 
 	context.subscriptions.push(
@@ -132,9 +131,15 @@ export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(
 		vscode.tasks.onDidStartTask((e) => {
 			if (e.execution.task.definition.type === "austin") {
+				const isAttach = e.execution.task.definition.pid !== undefined;
+				detachStatusBarItem.text = isAttach
+					? "$(debug-disconnect) Detach Austin"
+					: "$(debug-stop) Terminate Austin";
 				detachStatusBarItem.show();
 				pauseStatusBarItem.show();
-				flameGraphViewProvider.showDetachButton();
+				flameGraphViewProvider.showDetachButton(isAttach);
+				topProvider.showLive();
+				callStackProvider.showLive();
 			}
 		})
 	);
@@ -149,6 +154,8 @@ export function activate(context: vscode.ExtensionContext) {
 				pauseStatusBarItem.text = "$(debug-pause) Pause";
 				pauseStatusBarItem.tooltip = "Pause UI refreshes (data collection continues)";
 				flameGraphViewProvider.showOpenButton();
+				topProvider.hideLive();
+				callStackProvider.hideLive();
 			}
 		})
 	);
@@ -179,6 +186,30 @@ export function activate(context: vscode.ExtensionContext) {
 		})
 	);
 
+
+	// ---- Children toggle ----
+	const childrenStatusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100);
+	childrenStatusBarItem.command = "austin-vscode.toggleChildren";
+	childrenStatusBarItem.tooltip = "Toggle profiling of child processes (-C)";
+
+	let childrenEnabled = AustinRuntimeSettings.getChildren();
+
+	function updateChildrenStatusBar() {
+		childrenStatusBarItem.text = childrenEnabled
+			? "$(type-hierarchy-sub) Children: ON"
+			: "$(type-hierarchy-sub) Children: OFF";
+	}
+	updateChildrenStatusBar();
+
+	context.subscriptions.push(
+		vscode.commands.registerCommand("austin-vscode.toggleChildren", () => {
+			childrenEnabled = !childrenEnabled;
+			AustinRuntimeSettings.setChildren(childrenEnabled);
+			updateChildrenStatusBar();
+		})
+	);
+
+	childrenStatusBarItem.show();
 
 	// ---- Mode selector ----
 	const austinModeStatusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100);

--- a/src/providers/callstack.ts
+++ b/src/providers/callstack.ts
@@ -97,6 +97,14 @@ export class CallStackViewProvider implements vscode.WebviewViewProvider {
         this._view?.webview.postMessage({ loading: true });
     }
 
+    public showLive() {
+        this._view?.webview.postMessage({ live: true });
+    }
+
+    public hideLive() {
+        this._view?.webview.postMessage({ live: false });
+    }
+
     public focusPath(pathKey: string) {
         this._view?.webview.postMessage({ focus: { pathKey } });
     }
@@ -173,6 +181,20 @@ export class CallStackViewProvider implements vscode.WebviewViewProvider {
             opacity: 0.7;
         }
         .toolbar-btn:hover { opacity: 1; background: var(--vscode-list-hoverBackground); }
+        #live-dot {
+            width: 8px;
+            height: 8px;
+            border-radius: 50%;
+            background: #e74c3c;
+            flex-shrink: 0;
+            display: none;
+            margin-left: 2px;
+        }
+        #live-dot.active { display: block; animation: live-pulse 1.4s ease-in-out infinite; }
+        @keyframes live-pulse {
+            0%, 100% { opacity: 1; }
+            50%       { opacity: 0.3; }
+        }
         table {
             width: 100%;
             border-collapse: collapse;
@@ -291,6 +313,7 @@ export class CallStackViewProvider implements vscode.WebviewViewProvider {
                 <path d="M5.5 5L8 7.5L10.5 5M5.5 11L8 8.5L10.5 11" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
             </svg>
         </button>
+        <span id="live-dot" title="Live session active"></span>
     </div>
     <div id="empty" class="empty">No profiling data loaded.</div>
     <table id="table" style="display:none">

--- a/src/providers/executor.ts
+++ b/src/providers/executor.ts
@@ -40,7 +40,8 @@ export class AustinCommandExecutor implements vscode.Pseudoterminal {
     private cwd: string,
     private output: vscode.OutputChannel,
     private stats: AustinStats,
-    private fileName: string | undefined
+    private fileName: string | undefined,
+    private isAttach: boolean = false,
   ) { }
 
   private writeEmitter = new vscode.EventEmitter<string>();
@@ -92,8 +93,11 @@ export class AustinCommandExecutor implements vscode.Pseudoterminal {
       });
 
       let lastTotal = 0;
+      let firstTick = true;
       const refreshInterval = setInterval(() => {
-        if (!this.stats.paused && this.stats.overallTotal > lastTotal) {
+        const hasNewData = this.stats.overallTotal > lastTotal;
+        if (!this.stats.paused && (firstTick || hasNewData)) {
+          firstTick = false;
           lastTotal = this.stats.overallTotal;
           this.stats.refresh();
         }
@@ -103,11 +107,16 @@ export class AustinCommandExecutor implements vscode.Pseudoterminal {
         this._processExited = true;
         clearInterval(refreshInterval);
         if (this._killed) {
-          // Intentional detach: we sent a kill signal before the process exited
-          this.writeEmitter.fire("Austin detached.\r\n");
+          // Intentional stop: we sent a kill signal before the process exited
           this.closeEmitter.fire(0);
           const label = fileName ?? "process";
-          vscode.window.showInformationMessage(`Austin detached from ${label}.`);
+          if (this.isAttach) {
+            this.writeEmitter.fire("Austin detached.\r\n");
+            vscode.window.showInformationMessage(`Austin detached from ${label}.`);
+          } else {
+            this.writeEmitter.fire("Austin terminated.\r\n");
+            vscode.window.showInformationMessage(`Austin terminated ${label}.`);
+          }
           parser.finalize();
           this.stats.refresh();
         } else if (code !== 0) {
@@ -115,6 +124,8 @@ export class AustinCommandExecutor implements vscode.Pseudoterminal {
           this.result = code!;
           this.closeEmitter.fire(code!);
           vscode.window.showErrorMessage(`Austin exited with code ${code}. Check the Austin output channel for details.`);
+          parser.finalize();
+          this.stats.refresh();
         } else {
           this.writeEmitter.fire("Profiling complete.\r\n");
           this.closeEmitter.fire(0);

--- a/src/providers/flamegraph.ts
+++ b/src/providers/flamegraph.ts
@@ -14,6 +14,7 @@ export class FlameGraphViewProvider implements vscode.WebviewViewProvider {
     private _initialized: boolean = false;
     private _onFrameSelected?: (pathKey: string) => void;
     private _sessionActive: boolean = false;
+    private _isAttach: boolean = false;
     private _flameHtmlSet: boolean = false;
 
     constructor(
@@ -44,6 +45,12 @@ export class FlameGraphViewProvider implements vscode.WebviewViewProvider {
                 this._initialized = true;
                 if (this._stats) {
                     this.refresh(this._stats);
+                }
+                // Sync live/button state in case it changed while the webview was (re)loading
+                if (this._sessionActive) {
+                    this._view?.webview.postMessage(this._isAttach ? 'showDetach' : 'showTerminate');
+                } else {
+                    this._view?.webview.postMessage('showOpen');
                 }
                 return;
             }
@@ -115,10 +122,11 @@ export class FlameGraphViewProvider implements vscode.WebviewViewProvider {
         this._view?.webview.postMessage({ focus: pathKey });
     }
 
-    public showDetachButton() {
+    public showDetachButton(isAttach: boolean = true) {
         this._sessionActive = true;
+        this._isAttach = isAttach;
         if (this._initialized) {
-            this._view?.webview.postMessage('showDetach');
+            this._view?.webview.postMessage(isAttach ? 'showDetach' : 'showTerminate');
         }
     }
 
@@ -157,8 +165,9 @@ export class FlameGraphViewProvider implements vscode.WebviewViewProvider {
         const austinCssUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, 'media', 'austin.css'));
         const austinLogoUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, 'media', 'austin-light.svg'));
 
-        const btnText = this._sessionActive ? 'Detach' : 'Open';
+        const btnText = this._sessionActive ? (this._isAttach ? 'Detach' : 'Terminate') : 'Open';
         const btnOnclick = this._sessionActive ? 'onDetach()' : 'onOpen()';
+        const liveClass = this._sessionActive ? ' live' : '';
 
         webview.html = `<!DOCTYPE html>
 			<html lang="en">
@@ -166,7 +175,7 @@ export class FlameGraphViewProvider implements vscode.WebviewViewProvider {
                 <link rel="stylesheet" type="text/css" href="${austinCssUri}">
             </head>
             <body class="logo">
-                <div id="header"><img src="${austinLogoUri}" /><span class="vc" id="mode"></span><input id="search-box" type="text" placeholder="Search…" /><button id="header-open" onclick="${btnOnclick}">${btnText}</button></div>
+                <div id="header"><img id="austin-logo" class="${liveClass}" src="${austinLogoUri}" /><span class="vc" id="mode"></span><input id="search-box" type="text" placeholder="Search…" /><button id="header-open" onclick="${btnOnclick}">${btnText}</button></div>
                 <div id="chart"></div>
                 <div id="footer"></div>
 
@@ -177,12 +186,19 @@ export class FlameGraphViewProvider implements vscode.WebviewViewProvider {
                 function onDetach() { window.vscode.postMessage("detach"); }
                 window.addEventListener('message', function(e) {
                     var btn = document.getElementById('header-open');
+                    var logo = document.getElementById('austin-logo');
                     if (e.data === 'showDetach') {
                         btn.textContent = 'Detach';
                         btn.onclick = onDetach;
+                        logo.classList.add('live');
+                    } else if (e.data === 'showTerminate') {
+                        btn.textContent = 'Terminate';
+                        btn.onclick = onDetach;
+                        logo.classList.add('live');
                     } else if (e.data === 'showOpen') {
                         btn.textContent = 'Open';
                         btn.onclick = onOpen;
+                        logo.classList.remove('live');
                     }
                 });
                 </script>
@@ -194,6 +210,8 @@ export class FlameGraphViewProvider implements vscode.WebviewViewProvider {
         if (this._view === undefined || this._view.webview === undefined) {
             return;
         }
+        this._initialized = false;
+        this._flameHtmlSet = false;
         const webview = this._view.webview;
         const austinCssUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, 'media', 'austin.css'));
 

--- a/src/providers/task.ts
+++ b/src/providers/task.ts
@@ -107,6 +107,7 @@ export class AustinProfileTaskProvider implements vscode.TaskProvider {
           this.output,
           this.stats,
           fileName,
+          definition.pid !== undefined,
         );
       })
     );

--- a/src/providers/top.ts
+++ b/src/providers/top.ts
@@ -77,6 +77,14 @@ export class TopViewProvider implements vscode.WebviewViewProvider {
         this._view?.webview.postMessage({ loading: true });
     }
 
+    public showLive() {
+        this._view?.webview.postMessage({ live: true });
+    }
+
+    public hideLive() {
+        this._view?.webview.postMessage({ live: false });
+    }
+
     public refresh(stats: AustinStats) {
         this._stats = stats;
         if (this._view && this._initialized) {
@@ -313,6 +321,20 @@ export class TopViewProvider implements vscode.WebviewViewProvider {
             opacity: 0.7;
         }
         .toolbar-btn:hover { opacity: 1; background: var(--vscode-list-hoverBackground); }
+        #live-dot {
+            width: 8px;
+            height: 8px;
+            border-radius: 50%;
+            background: #e74c3c;
+            flex-shrink: 0;
+            display: none;
+            margin-left: 2px;
+        }
+        #live-dot.active { display: block; animation: live-pulse 1.4s ease-in-out infinite; }
+        @keyframes live-pulse {
+            0%, 100% { opacity: 1; }
+            50%       { opacity: 0.3; }
+        }
         .empty {
             padding: 24px 16px;
             color: var(--vscode-descriptionForeground);
@@ -359,6 +381,7 @@ export class TopViewProvider implements vscode.WebviewViewProvider {
                 <path d="M5.5 5L8 7.5L10.5 5M5.5 11L8 8.5L10.5 11" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
             </svg>
         </button>
+        <span id="live-dot" title="Live session active"></span>
     </div>
     <div id="empty" class="empty">No profiling data loaded.</div>
     <table id="table" style="display:none">

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -20,12 +20,14 @@ export class AustinRuntimeSettings {
         const austinInterval: number = AustinRuntimeSettings.config.get<number>("interval", DEFAULT_INTERVAL);
         const austinMode: AustinMode = AustinRuntimeSettings.config.get("mode", DEFAULT_MODE);
         const austinLineStats: AustinLineStats = AustinRuntimeSettings.config.get("lineStats", DEFAULT_LINE_STATS);
+        const austinChildren: boolean = AustinRuntimeSettings.config.get("children", false);
 
         this.settings = {
             path: austinPath,
             mode: austinMode,
             interval: austinInterval,
-            lineStats: austinLineStats
+            lineStats: austinLineStats,
+            children: austinChildren,
         };
     }
 
@@ -65,5 +67,13 @@ export class AustinRuntimeSettings {
 
     public static setLineStats(newLineStats: AustinLineStats) {
         AustinRuntimeSettings.config.update("lineStats", newLineStats, vscode.ConfigurationTarget.Global);
+    }
+
+    public static getChildren(): boolean {
+        return AustinRuntimeSettings.get().settings.children;
+    }
+
+    public static setChildren(children: boolean) {
+        AustinRuntimeSettings.config.update("children", children, vscode.ConfigurationTarget.Global);
     }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,5 +20,6 @@ export class AustinSettings {
     path: string = "austin";
     mode: AustinMode = AustinMode.CpuTime;
     interval: number = 100;
-lineStats: AustinLineStats = AustinLineStats.PERCENT;
+    lineStats: AustinLineStats = AustinLineStats.PERCENT;
+    children: boolean = false;
 }

--- a/src/utils/commandFactory.ts
+++ b/src/utils/commandFactory.ts
@@ -38,6 +38,7 @@ export function getAustinCommand(
 
     if (_mode === AustinMode.CpuTime) { _args.push("-c"); }
     if (_mode === AustinMode.Memory) { _args.push("-m"); }
+    if (settings.children) { _args.push("-C"); }
     if (austinArgs) { _args = _args.concat(austinArgs); }
     if (pid !== undefined) {
         _args.push("-p", `${pid}`);


### PR DESCRIPTION
- Add pulsating live indicator dot to Top and Call Stacks views during active sessions
- Show "Terminate" vs "Detach" in flamegraph button and status bar depending on session type (profile vs attach)
- Show "terminated" vs "detached" in info notifications accordingly
- Preserve flamegraph zoom/focus across periodic live data updates using stable pathKey identifiers
- Fix spinner stuck on second profile run by resetting webview state flags in showLoading()
- Fix Austin logo pulsating after session ends by syncing button/live state in webview "initialized" handler
- Add Children toggle status bar item to enable/disable -C flag for child process profiling
- Fix children toggle label sync by tracking state in a local variable instead of re-reading async config
- Fix attach mode: views no longer show spinners for entire session; UI refreshes after first tick regardless of data arrival
- Fix spinner not cleared when Austin exits with non-zero code