### PR TITLE
chore: attach target list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "dotenv": "^16.3.1"
+        "dotenv": "^16.3.1",
+        "ps-list": "^7.2.0"
       },
       "devDependencies": {
         "@types/glob": "^7.1.3",
@@ -2738,6 +2739,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/ps-list": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/ps-list/-/ps-list-7.2.0.tgz",
+      "integrity": "sha512-v4Bl6I3f2kJfr5o80ShABNHAokIgY+wFDTQfE+X3zWYgSGQOCBeYptLZUpoOALBqO5EawmDN/tjTldJesd0ujQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -4898,6 +4911,11 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
+    },
+    "ps-list": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/ps-list/-/ps-list-7.2.0.tgz",
+      "integrity": "sha512-v4Bl6I3f2kJfr5o80ShABNHAokIgY+wFDTQfE+X3zWYgSGQOCBeYptLZUpoOALBqO5EawmDN/tjTldJesd0ujQ=="
     },
     "punycode": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -248,6 +248,7 @@
     "ms-python.python"
   ],
   "dependencies": {
-    "dotenv": "^16.3.1"
+    "dotenv": "^16.3.1",
+    "ps-list": "^7.2.0"
   }
 }

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -5,6 +5,7 @@ import { isPythonExtensionAvailable } from './utils/pythonExtension';
 import { AustinProfileTaskProvider } from './providers/task';
 import { AustinRuntimeSettings } from './settings';
 import { AustinVersionError, checkAustinVersion } from './utils/versionCheck';
+import psList = require('ps-list');
 
 
 export class AustinController {
@@ -49,19 +50,52 @@ export class AustinController {
     public async attachProcess() {
         if (!await this.checkVersion()) { return; }
 
-        const pidStr = await vscode.window.showInputBox({
-            prompt: "Enter the PID of the Python process to attach to",
-            placeHolder: "e.g. 12345",
-            validateInput: (value) => {
-                if (!/^\d+$/.test(value) || parseInt(value) <= 0) {
-                    return "Please enter a valid process ID (positive integer).";
-                }
-            },
+        const MANUAL_ENTRY = "$(edit) Enter PID manually...";
+
+        let pid: number | undefined;
+
+        const processes = await psList();
+        const pythonProcs = processes
+            .filter(p => /python/i.test(p.name) || /python/i.test(p.cmd ?? ""))
+            .sort((a, b) => a.pid - b.pid)
+            .map(p => ({
+                label: `$(terminal) ${p.pid}`,
+                description: p.name,
+                detail: p.cmd,
+                pid: p.pid,
+            }));
+
+        type ProcItem = typeof pythonProcs[0];
+        type ManualItem = { label: string; pid?: undefined };
+        const items: (ProcItem | ManualItem)[] = [{ label: MANUAL_ENTRY }, ...pythonProcs];
+
+        const picked = await vscode.window.showQuickPick(items, {
+            title: "Attach Austin to Python Process",
+            placeHolder: pythonProcs.length
+                ? "Select a Python process or enter a PID manually"
+                : "No Python processes found — enter a PID manually",
+            matchOnDescription: true,
+            matchOnDetail: true,
         });
 
-        if (!pidStr) { return; }
+        if (!picked) { return; }
 
-        const pid = parseInt(pidStr);
+        if (picked.pid !== undefined) {
+            pid = picked.pid;
+        } else {
+            const pidStr = await vscode.window.showInputBox({
+                prompt: "Enter the PID of the process to attach to",
+                placeHolder: "e.g. 12345",
+                validateInput: (value) => {
+                    if (!/^\d+$/.test(value) || parseInt(value) <= 0) {
+                        return "Please enter a valid process ID (positive integer).";
+                    }
+                },
+            });
+            if (!pidStr) { return; }
+            pid = parseInt(pidStr);
+        }
+
         const task = this.provider.buildTaskFromPid(pid);
         this._currentExecution = await vscode.tasks.executeTask(task);
     }


### PR DESCRIPTION
We enhance the attach command by displaying a list of all possible Python processes that the user can attach to. If the intended process is not listed, the user can still enter the PID manually.