### PR TITLE
feat: add flamegraph share button

### DIFF
--- a/media/austin.css
+++ b/media/austin.css
@@ -76,7 +76,7 @@ button {
 #search-box::placeholder { color: rgba(255,235,205,0.4); }
 #search-box:focus { border-color: rgba(255,255,255,0.5); background: rgba(0,0,0,0.4); }
 
-#header-open {
+#header-open, #header-share {
     margin-left: 4px;
     flex-shrink: 0;
     background: none !important;
@@ -93,7 +93,7 @@ button {
     opacity: 0.75;
 }
 
-#header-open:hover {
+#header-open:hover, #header-share:hover {
     opacity: 1;
     background: rgba(255, 255, 255, 0.1) !important;
 }

--- a/src/flamegraph-svg.ts
+++ b/src/flamegraph-svg.ts
@@ -1,0 +1,488 @@
+// Generates a self-contained interactive SVG flamegraph, similar to Brendan Gregg's
+// flamegraph.pl. When opened directly in a browser the embedded JavaScript provides
+// zoom-on-click, search/highlight, hover tooltips, and keyboard shortcuts.
+
+const CELL_H = 24;
+const HEADER_H = 32;
+const FOOTER_H = 28;
+const LABEL_MIN_W = 30;
+const INIT_W = 1200;   // coordinate width used for initial (pre-JS) layout
+
+// ── Utilities (mirrors flamegraph-utils.js) ────────────────────────────────────
+
+function hslToHex(h: number, s: number, l: number): string {
+    l /= 100;
+    const a = s * Math.min(l, 1 - l) / 100;
+    const f = (n: number) => {
+        const k = (n + h / 30) % 12;
+        const c = l - a * Math.max(Math.min(k - 3, 9 - k, 1), -1);
+        return Math.round(255 * c).toString(16).padStart(2, '0');
+    };
+    return `#${f(0)}${f(8)}${f(4)}`;
+}
+
+function nodeHash(text: string): number {
+    let h = 0;
+    for (let i = 0; i < text.length; i++) { h = text.charCodeAt(i) + ((h << 5) - h); }
+    return h;
+}
+
+function colorFor(node: any): string {
+    if (!isNaN(+node.name)) { return '#808080'; }
+    const d = node.data ?? {};
+    const scope: string = d.name || node.name || '';
+    const mod: string | undefined = d.file;
+    if (!mod) { return hslToHex(0, 10, 70); }
+    const sat = nodeHash(scope) % 20;
+    switch (scope.charAt(0)) {
+        case 'P': return hslToHex(120, sat, 70);
+        case 'T': return hslToHex(240, sat, 70);
+        default: {
+            const h = nodeHash(mod) % 360;
+            const s = nodeHash(scope) % 10;
+            return hslToHex(h >= 0 ? h : -h, (mod.endsWith('.py') ? 60 : 20) + s, 60);
+        }
+    }
+}
+
+function nodeBasename(p: string): string {
+    return p ? p.replace(/\\/g, '/').split('/').pop() || p : '';
+}
+
+function escXml(s: string): string {
+    return String(s || '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
+}
+
+function formatValue(v: number, mode: string): string {
+    if (mode === 'memory') {
+        if (v < 1024)            { return v.toFixed(0) + ' B'; }
+        if (v < 1024 * 1024)     { return (v / 1024).toFixed(2) + ' KB'; }
+        if (v < Math.pow(1024, 3)) { return (v / Math.pow(1024, 2)).toFixed(2) + ' MB'; }
+        return (v / Math.pow(1024, 3)).toFixed(2) + ' GB';
+    }
+    if (v < 1000) { return v.toFixed(0) + ' \u03BCs'; }
+    if (v < 1e6)  { return (v / 1000).toFixed(2) + ' ms'; }
+    if (v < 1e9)  { return (v / 1e6).toFixed(2) + ' s'; }
+    return (v / 1e9).toFixed(2) + ' m';
+}
+
+// ── Layout (mirrors flamegraph.js) ─────────────────────────────────────────────
+
+interface Frame {
+    node: any;
+    x: number;
+    y: number;
+    w: number;
+    depth: number;
+    color: string;
+    ancestor: boolean;
+}
+
+function layoutFrames(zoomRoot: any, cssWidth: number, ancestors: any[]): { frames: Frame[]; rows: number } {
+    const frames: Frame[] = [];
+    let maxDepth = 0;
+
+    for (let i = 0; i < ancestors.length; i++) {
+        frames.push({ node: ancestors[i], x: 0, y: i * CELL_H, w: cssWidth, depth: i, color: colorFor(ancestors[i]), ancestor: true });
+        maxDepth = Math.max(maxDepth, i);
+    }
+
+    const offset = ancestors.length;
+    const queue: Array<{ node: any; x: number; depth: number; w: number }> = [
+        { node: zoomRoot, x: 0, depth: offset, w: cssWidth }
+    ];
+
+    while (queue.length) {
+        const { node, x, depth, w } = queue.shift()!;
+        frames.push({ node, x, y: depth * CELL_H, w, depth, color: colorFor(node), ancestor: false });
+        maxDepth = Math.max(maxDepth, depth);
+        if (!node.children?.length) { continue; }
+        const scale = w / node.value;
+        let childX = x;
+        for (const child of node.children) {
+            const childW = child.value * scale;
+            if (childW >= 1) { queue.push({ node: child, x: childX, depth: depth + 1, w: childW }); }
+            childX += childW;
+        }
+    }
+
+    return { frames, rows: maxDepth + 1 };
+}
+
+// ── Public API ─────────────────────────────────────────────────────────────────
+
+export function generateInteractiveSVG(hierarchy: any, mode: string, logoB64?: string): string {
+    // Deep-clone and stamp a stable numeric _id on every node so the embedded JS
+    // can map SVG element IDs back to tree nodes in O(1).
+    const root: any = JSON.parse(JSON.stringify(hierarchy));
+    let idCounter = 0;
+    function assignIds(node: any): void {
+        node._id = idCounter++;
+        if (node.children) { node.children.forEach(assignIds); }
+    }
+    assignIds(root);
+
+    const modeLabels: Record<string, string> = {
+        cpu: 'CPU Time Profile', wall: 'Wall Time Profile', memory: 'Memory Allocations Profile',
+    };
+    const headerColors: Record<string, string> = {
+        cpu: 'rgba(192,64,64,0.85)', wall: 'rgba(160,160,48,0.85)', memory: 'rgba(48,160,48,0.85)',
+    };
+    const bgColors: Record<string, string> = {
+        cpu: '#1a0505', wall: '#1a1a05', memory: '#051a05',
+    };
+
+    const modeLabel  = modeLabels[mode]  || mode;
+    const headerColor = headerColors[mode] || headerColors.cpu;
+    const bgColor     = bgColors[mode]    || bgColors.cpu;
+
+    // Initial layout at INIT_W so the SVG is meaningful without JS.
+    const { frames, rows } = layoutFrames(root, INIT_W, []);
+    const svgH = HEADER_H + rows * CELL_H + FOOTER_H;
+
+    // ── Generate per-frame SVG elements ──────────────────────────────────────
+
+    const clipDefs: string[] = [];
+    const frameEls: string[] = [];
+
+    for (const f of frames) {
+        const id: number = f.node._id;
+        const fy = HEADER_H + f.y;
+        const opacity = f.ancestor ? 0.45 : 1;
+        const d = f.node.data ?? {};
+        const funcName: string = f.node.name || '';
+        const file: string = d.file ? nodeBasename(d.file) : '';
+        const pct = (f.node.value / root.value * 100).toFixed(2) + '%';
+        const titleText = escXml(
+            funcName + (d.file ? '\n' + d.file : '') + '\n' + formatValue(f.node.value, mode) + ' (' + pct + ')'
+        );
+        const labelAlpha = f.ancestor ? 0.6 : 0.9;
+
+        // Clip path — kept in sync by JS on every render.
+        clipDefs.push(
+            `<clipPath id="c${id}">` +
+            `<rect id="cr${id}" x="${f.x.toFixed(1)}" y="${fy}" ` +
+            `width="${Math.max(0, f.w - 4).toFixed(1)}" height="${CELL_H}"/>` +
+            `</clipPath>`
+        );
+
+        const textContent = escXml(funcName) +
+            (file ? ` <tspan opacity="0.5">${escXml(file)}</tspan>` : '');
+        const textHide = f.w < LABEL_MIN_W ? ' display="none"' : '';
+
+        frameEls.push(
+            `<g class="frame" id="f${id}" data-id="${id}" style="cursor:pointer">` +
+            `<rect id="r${id}" x="${f.x.toFixed(1)}" y="${fy}" ` +
+            `width="${f.w.toFixed(1)}" height="${CELL_H}" ` +
+            `fill="${f.color}" opacity="${opacity}" ` +
+            `stroke="rgba(0,0,0,0.18)" stroke-width="0.5"/>` +
+            `<text id="t${id}" clip-path="url(#c${id})" ` +
+            `x="${(f.x + 4).toFixed(1)}" y="${(fy + CELL_H / 2).toFixed(1)}" ` +
+            `dominant-baseline="middle" font-size="13" ` +
+            `fill="rgba(255,255,255,${labelAlpha})"${textHide}>${textContent}</text>` +
+            `<title>${titleText}</title>` +
+            `</g>`
+        );
+    }
+
+    // Embed data as base64 to sidestep all XML/CDATA escaping concerns.
+    const dataB64 = Buffer.from(JSON.stringify({ hierarchy: root, mode })).toString('base64');
+
+    return [
+        `<svg xmlns="http://www.w3.org/2000/svg"`,
+        `     width="100%" height="${svgH}"`,
+        `     style="background:${bgColor};font-family:system-ui,sans-serif;display:block">`,
+        ``,
+        `  <defs>`,
+        ...clipDefs.map(d => `    ${d}`),
+        `  </defs>`,
+        ``,
+        `  <!-- Header -->`,
+        `  <rect x="0" y="0" width="100%" height="${HEADER_H}" fill="${headerColor}"`,
+        `        style="filter:drop-shadow(0 0 6px #000)"/>`,
+        ...(logoB64 ? [
+            `  <image href="data:image/svg+xml;base64,${logoB64}" x="4" y="4" width="24" height="24"/>`,
+        ] : []),
+        `  <text x="${logoB64 ? 32 : 8}" y="${HEADER_H / 2}" dominant-baseline="middle"`,
+        `        font-size="13" font-weight="bold" fill="antiquewhite">${escXml(modeLabel)}</text>`,
+        `  <foreignObject id="fo-search" x="${INIT_W - 210}" y="5" width="160" height="22">`,
+        `    <input xmlns="http://www.w3.org/1999/xhtml" id="search-input" type="text"`,
+        `           placeholder="Search\u2026"`,
+        `           style="width:100%;box-sizing:border-box;background:rgba(0,0,0,0.3);` +
+        `border:1px solid rgba(255,255,255,0.25);border-radius:4px;` +
+        `color:antiquewhite;font-size:11px;padding:2px 6px;outline:none"/>`,
+        `  </foreignObject>`,
+        `  <g id="reset-btn" style="cursor:pointer" transform="translate(${INIT_W - 46},4)">`,
+        `    <rect rx="4" width="40" height="24" fill="none"`,
+        `          stroke="rgba(255,255,255,0.3)" stroke-width="1"/>`,
+        `    <text x="20" y="16" text-anchor="middle" font-size="10" font-weight="600"`,
+        `          fill="antiquewhite" letter-spacing="0.04em">RESET</text>`,
+        `  </g>`,
+        ``,
+        `  <!-- Frames -->`,
+        `  <g id="frames-group">`,
+        ...frameEls.map(el => `    ${el}`),
+        `  </g>`,
+        ``,
+        `  <!-- Footer -->`,
+        `  <rect id="footer-bg" x="0" y="${svgH - FOOTER_H}" width="100%"`,
+        `        height="${FOOTER_H}" fill="rgba(46,53,58,0.9)"`,
+        `        style="filter:drop-shadow(0 0 6px #000)"/>`,
+        `  <text id="footer-text" x="6" y="${svgH - FOOTER_H / 2}"`,
+        `        dominant-baseline="middle" font-size="12" fill="antiquewhite"/>`,
+        ``,
+        `  <!-- Embedded profile data (base64 JSON) -->`,
+        `  <script type="application/json" id="fg-data">${dataB64}</script>`,
+        ``,
+        `  <!-- Interactive script -->`,
+        `  <script><![CDATA[`,
+        buildEmbeddedScript(),
+        `  ]]></script>`,
+        `</svg>`,
+    ].join('\n');
+}
+
+// ── Embedded JavaScript ────────────────────────────────────────────────────────
+// Written with String.raw to avoid double-escaping backslashes.
+
+function buildEmbeddedScript(): string {
+    return String.raw`
+(function () {
+    // ── Data ──────────────────────────────────────────────────────────────────
+    const { hierarchy, mode } = JSON.parse(atob(document.getElementById('fg-data').textContent.trim()));
+    const TOTAL = hierarchy.value;
+
+    // O(1) node lookup by _id
+    const nodeMap = new Map();
+    (function index(n) { nodeMap.set(n._id, n); if (n.children) n.children.forEach(index); })(hierarchy);
+
+    // ── Constants ─────────────────────────────────────────────────────────────
+    const CELL_H = 24, HEADER_H = 32, FOOTER_H = 28, LABEL_MIN_W = 30;
+
+    // ── Utilities ─────────────────────────────────────────────────────────────
+    function hslToHex(h, s, l) {
+        l /= 100;
+        const a = s * Math.min(l, 1 - l) / 100;
+        const f = n => { const k = (n + h / 30) % 12; const c = l - a * Math.max(Math.min(k - 3, 9 - k, 1), -1); return Math.round(255 * c).toString(16).padStart(2, '0'); };
+        return '#' + f(0) + f(8) + f(4);
+    }
+    function nhash(t) { let h = 0; for (let i = 0; i < t.length; i++) { h = t.charCodeAt(i) + ((h << 5) - h); } return h; }
+    function colorFor(n) {
+        if (!isNaN(+n.name)) { return '#808080'; }
+        const d = n.data || {}, scope = d.name || n.name || '', mod = d.file;
+        if (!mod) { return hslToHex(0, 10, 70); }
+        const sat = nhash(scope) % 20;
+        if (scope[0] === 'P') { return hslToHex(120, sat, 70); }
+        if (scope[0] === 'T') { return hslToHex(240, sat, 70); }
+        const h = nhash(mod) % 360;
+        return hslToHex(h >= 0 ? h : -h, (mod.endsWith('.py') ? 60 : 20) + nhash(scope) % 10, 60);
+    }
+    function basename(p) { return p ? p.replace(/\\/g, '/').split('/').pop() || p : ''; }
+    function fmt(v) {
+        if (mode === 'memory') {
+            if (v < 1024)       { return v.toFixed(0) + ' B'; }
+            if (v < 1048576)    { return (v / 1024).toFixed(2) + ' KB'; }
+            if (v < 1073741824) { return (v / 1048576).toFixed(2) + ' MB'; }
+            return (v / 1073741824).toFixed(2) + ' GB';
+        }
+        if (v < 1000) { return v.toFixed(0) + ' \u03BCs'; }
+        if (v < 1e6)  { return (v / 1000).toFixed(2) + ' ms'; }
+        if (v < 1e9)  { return (v / 1e6).toFixed(2) + ' s'; }
+        return (v / 1e9).toFixed(2) + ' m';
+    }
+
+    // ── Layout ────────────────────────────────────────────────────────────────
+    function findAncestors(root, target) {
+        const path = [];
+        function walk(n) {
+            if (n === target) { return true; }
+            if (n.children) { for (const c of n.children) { path.push(n); if (walk(c)) { return true; } path.pop(); } }
+            return false;
+        }
+        walk(root);
+        return path;
+    }
+
+    function doLayout(zoomRoot, w, ancestors) {
+        const frames = [];
+        let maxD = 0;
+        ancestors.forEach((a, i) => {
+            frames.push({ node: a, x: 0, y: i * CELL_H, w, depth: i, ancestor: true });
+            maxD = Math.max(maxD, i);
+        });
+        const q = [{ node: zoomRoot, x: 0, depth: ancestors.length, w }];
+        while (q.length) {
+            const { node, x, depth, w: fw } = q.shift();
+            frames.push({ node, x, y: depth * CELL_H, w: fw, depth, ancestor: false });
+            maxD = Math.max(maxD, depth);
+            if (!node.children || !node.children.length) { continue; }
+            const scale = fw / node.value;
+            let cx = x;
+            for (const child of node.children) {
+                const cw = child.value * scale;
+                if (cw >= 1) { q.push({ node: child, x: cx, depth: depth + 1, w: cw }); }
+                cx += cw;
+            }
+        }
+        return { frames, rows: maxD + 1 };
+    }
+
+    // ── State ─────────────────────────────────────────────────────────────────
+    let zoomNode = null;
+    let searchTerm = '';
+    const svg = document.querySelector('svg');
+
+    // ── Render ────────────────────────────────────────────────────────────────
+    function render() {
+        const w = svg.getBoundingClientRect().width || 1200;
+        const ancestors = zoomNode ? findAncestors(hierarchy, zoomNode) : [];
+        const { frames, rows } = doLayout(zoomNode || hierarchy, w, ancestors);
+        const totalH = HEADER_H + rows * CELL_H + FOOTER_H;
+
+        svg.setAttribute('height', totalH);
+
+        // Reposition footer
+        const fb = document.getElementById('footer-bg');
+        const ft = document.getElementById('footer-text');
+        if (fb) { fb.setAttribute('y', totalH - FOOTER_H); }
+        if (ft) { ft.setAttribute('y', totalH - FOOTER_H / 2); ft.textContent = ''; }
+
+        // Keep header-right elements anchored to the right edge
+        const foSearch = document.getElementById('fo-search');
+        const resetBtn = document.getElementById('reset-btn');
+        if (foSearch) { foSearch.setAttribute('x', w - 210); }
+        if (resetBtn) { resetBtn.setAttribute('transform', 'translate(' + (w - 46) + ',4)'); }
+
+        // Build the set of node IDs visible in this layout
+        const visible = new Set(frames.map(f => f.node._id));
+
+        // Hide frames not in current layout
+        document.querySelectorAll('.frame').forEach(el => {
+            el.style.display = visible.has(+el.getAttribute('data-id')) ? '' : 'none';
+        });
+
+        // Update each visible frame's geometry
+        for (const f of frames) {
+            const id   = f.node._id;
+            const fy   = HEADER_H + f.y;
+            const op   = f.ancestor ? 0.45 : 1;
+            const alpha = f.ancestor ? 0.6 : 0.9;
+
+            const rect = document.getElementById('r' + id);
+            const cr   = document.getElementById('cr' + id);
+            const text = document.getElementById('t' + id);
+
+            if (rect) {
+                rect.setAttribute('x',       f.x);
+                rect.setAttribute('y',       fy);
+                rect.setAttribute('width',   f.w);
+                rect.setAttribute('opacity', op);
+                rect.setAttribute('fill',    colorFor(f.node));
+            }
+            if (cr) {
+                cr.setAttribute('x',     f.x);
+                cr.setAttribute('y',     fy);
+                cr.setAttribute('width', Math.max(0, f.w - 4));
+            }
+            if (text) {
+                text.setAttribute('x',    f.x + 4);
+                text.setAttribute('y',    fy + CELL_H / 2);
+                text.setAttribute('fill', 'rgba(255,255,255,' + alpha + ')');
+                text.style.display = f.w >= LABEL_MIN_W ? 'inline' : 'none';
+            }
+        }
+
+        applySearch();
+    }
+
+    // ── Search ────────────────────────────────────────────────────────────────
+    function applySearch() {
+        document.querySelectorAll('.frame').forEach(el => {
+            const id   = +el.getAttribute('data-id');
+            const node = nodeMap.get(id);
+            const rect = document.getElementById('r' + id);
+            if (!node || !rect) { return; }
+            if (!searchTerm) {
+                rect.setAttribute('stroke',       'rgba(0,0,0,0.18)');
+                rect.setAttribute('stroke-width', '0.5');
+                return;
+            }
+            const d = node.data || {};
+            const match = (node.name || '').toLowerCase().includes(searchTerm) ||
+                          (d.file || '').toLowerCase().includes(searchTerm);
+            rect.setAttribute('stroke',       match ? 'rgba(255,230,80,0.95)' : 'rgba(0,0,0,0.18)');
+            rect.setAttribute('stroke-width', match ? '2' : '0.5');
+        });
+    }
+
+    // ── Events ────────────────────────────────────────────────────────────────
+    document.querySelectorAll('.frame').forEach(el => {
+        // Click: zoom in (or back out if clicking the current zoom root)
+        el.addEventListener('click', function () {
+            const node = nodeMap.get(+this.getAttribute('data-id'));
+            if (!node) { return; }
+            zoomNode = (zoomNode === node) ? null : node;
+            render();
+        });
+
+        // Hover: show details in footer
+        el.addEventListener('mouseenter', function () {
+            const node = nodeMap.get(+this.getAttribute('data-id'));
+            if (!node) { return; }
+            const d    = node.data || {};
+            const pct  = (node.value / TOTAL * 100).toFixed(2) + '%';
+            const icon = mode === 'memory' ? '\u{1F4E6}\uFE0E' : '\u23F1\uFE0E';
+            const ft   = document.getElementById('footer-text');
+            if (ft) {
+                ft.textContent = icon + ' ' + fmt(node.value) + ' (' + pct + ')' +
+                    '  \u00B7  ' + (d.name || node.name || '') +
+                    (d.file ? '  ' + basename(d.file) : '');
+            }
+        });
+        el.addEventListener('mouseleave', function () {
+            const ft = document.getElementById('footer-text');
+            if (ft) { ft.textContent = ''; }
+        });
+    });
+
+    // Reset button
+    const resetBtn = document.getElementById('reset-btn');
+    if (resetBtn) {
+        resetBtn.addEventListener('click', function () { zoomNode = null; render(); });
+    }
+
+    // Search input
+    const si = document.getElementById('search-input');
+    if (si) {
+        si.addEventListener('input', function () {
+            searchTerm = this.value.toLowerCase();
+            applySearch();
+        });
+        si.addEventListener('keydown', function (e) { e.stopPropagation(); });
+    }
+
+    // Keyboard shortcuts
+    document.addEventListener('keydown', function (e) {
+        if (e.ctrlKey || e.metaKey) { return; }
+        if (e.key === 'r' || e.key === 'R') { zoomNode = null; render(); }
+        if (e.key === 'f' || e.key === 'F') { if (si) { si.focus(); e.preventDefault(); } }
+        if (e.key === 'Escape') {
+            zoomNode = null;
+            searchTerm = '';
+            if (si) { si.value = ''; }
+            render();
+        }
+    });
+
+    // Reflow on resize
+    window.addEventListener('resize', render);
+
+    // ── Init ──────────────────────────────────────────────────────────────────
+    render();
+})();
+`;
+}

--- a/src/providers/flamegraph.ts
+++ b/src/providers/flamegraph.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { AustinStats } from '../model';
+import { generateInteractiveSVG } from '../flamegraph-svg';
 
 
 
@@ -62,6 +63,11 @@ export class FlameGraphViewProvider implements vscode.WebviewViewProvider {
 
             if (data === "detach") {
                 vscode.commands.executeCommand('austin-vscode.detach');
+                return;
+            }
+
+            if (data === "share") {
+                this._exportSVG();
                 return;
             }
 
@@ -175,7 +181,7 @@ export class FlameGraphViewProvider implements vscode.WebviewViewProvider {
                 <link rel="stylesheet" type="text/css" href="${austinCssUri}">
             </head>
             <body class="logo">
-                <div id="header"><img id="austin-logo" class="${liveClass}" src="${austinLogoUri}" /><span class="vc" id="mode"></span><input id="search-box" type="text" placeholder="Search…" /><button id="header-open" onclick="${btnOnclick}">${btnText}</button></div>
+                <div id="header"><img id="austin-logo" class="${liveClass}" src="${austinLogoUri}" /><span class="vc" id="mode"></span><input id="search-box" type="text" placeholder="Search…" /><button id="header-share" onclick="onShare()">SHARE</button><button id="header-open" onclick="${btnOnclick}">${btnText}</button></div>
                 <div id="chart"></div>
                 <div id="footer"></div>
 
@@ -184,6 +190,7 @@ export class FlameGraphViewProvider implements vscode.WebviewViewProvider {
                 <script>
                 function onOpen() { window.vscode.postMessage("open"); }
                 function onDetach() { window.vscode.postMessage("detach"); }
+                function onShare() { window.vscode.postMessage("share"); }
                 window.addEventListener('message', function(e) {
                     var btn = document.getElementById('header-open');
                     var logo = document.getElementById('austin-logo');
@@ -204,6 +211,36 @@ export class FlameGraphViewProvider implements vscode.WebviewViewProvider {
                 </script>
             </body>
 			</html>`;
+    }
+
+    private async _exportSVG(): Promise<void> {
+        if (!this._stats) {
+            vscode.window.showInformationMessage('No flamegraph data to export. Load a profile first.');
+            return;
+        }
+        const mode = this._stats.metadata.get('mode') || 'cpu';
+        const logoBytes = await vscode.workspace.fs.readFile(
+            vscode.Uri.joinPath(this._extensionUri, 'media', 'austin-light.svg')
+        );
+        const logoB64 = Buffer.from(logoBytes).toString('base64');
+        const svg = generateInteractiveSVG(this._stats.hierarchy, mode, logoB64);
+
+        const defaultUri = vscode.workspace.workspaceFolders?.[0]?.uri
+            ? vscode.Uri.joinPath(vscode.workspace.workspaceFolders[0].uri, 'flamegraph.svg')
+            : vscode.Uri.file('flamegraph.svg');
+
+        const dest = await vscode.window.showSaveDialog({
+            title: 'Export Flamegraph as Interactive SVG',
+            defaultUri,
+            filters: { 'SVG files': ['svg'] },
+        });
+        if (!dest) { return; }
+
+        await vscode.workspace.fs.writeFile(dest, Buffer.from(svg, 'utf8'));
+
+        vscode.window.showInformationMessage(
+            `Flamegraph exported to ${dest.fsPath} — open in a browser for full interactivity.`
+        );
     }
 
     public showLoading() {

--- a/src/test/suite/flamegraph-svg.test.ts
+++ b/src/test/suite/flamegraph-svg.test.ts
@@ -1,0 +1,246 @@
+import * as assert from 'assert';
+import { generateInteractiveSVG } from '../../flamegraph-svg';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const simpleHierarchy = {
+    key: 'root',
+    name: 'root',
+    value: 1000,
+    children: [
+        { key: 'a', name: 'func_a', value: 600, children: [], data: { name: 'func_a', file: '/app/module_a.py' } },
+        { key: 'b', name: 'func_b', value: 400, children: [], data: { name: 'func_b', file: '/app/module_b.py' } },
+    ],
+    data: {},
+};
+
+// tiny_func occupies 1/100 of width = 12 px at INIT_W=1200, below LABEL_MIN_W=30
+const hierWithNarrowFrame = {
+    key: 'root',
+    name: 'root',
+    value: 100,
+    children: [
+        { key: 'big',  name: 'big_func',  value: 99, children: [], data: { name: 'big_func',  file: 'a.py' } },
+        { key: 'tiny', name: 'tiny_func', value: 1,  children: [], data: { name: 'tiny_func', file: 'b.py' } },
+    ],
+    data: {},
+};
+
+// Helper: decode the base64 data blob embedded in the SVG
+function decodeEmbeddedData(svg: string): { hierarchy: any; mode: string } {
+    const match = svg.match(/id="fg-data">([A-Za-z0-9+/=]+)</);
+    assert.ok(match, 'fg-data element not found in SVG');
+    return JSON.parse(Buffer.from(match[1], 'base64').toString('utf8'));
+}
+
+// Helper: count occurrences of a substring
+function countOccurrences(haystack: string, needle: string): number {
+    return haystack.split(needle).length - 1;
+}
+
+// ── Structure ─────────────────────────────────────────────────────────────────
+
+suite('generateInteractiveSVG — structure', () => {
+    test('returns a string', () => {
+        assert.strictEqual(typeof generateInteractiveSVG(simpleHierarchy, 'cpu'), 'string');
+    });
+
+    test('output starts with <svg', () => {
+        const svg = generateInteractiveSVG(simpleHierarchy, 'cpu');
+        assert.ok(svg.trimStart().startsWith('<svg'), 'expected SVG root element');
+    });
+
+    test('contains header, frames group, and footer elements', () => {
+        const svg = generateInteractiveSVG(simpleHierarchy, 'cpu');
+        assert.ok(svg.includes('id="frames-group"'), 'missing frames-group');
+        assert.ok(svg.includes('id="footer-bg"'),    'missing footer-bg');
+        assert.ok(svg.includes('id="footer-text"'),  'missing footer-text');
+        assert.ok(svg.includes('id="reset-btn"'),    'missing reset-btn');
+        assert.ok(svg.includes('id="fo-search"'),    'missing search foreignObject');
+    });
+
+    test('contains an embedded interactive script', () => {
+        const svg = generateInteractiveSVG(simpleHierarchy, 'cpu');
+        assert.ok(svg.includes('<script><![CDATA['), 'missing CDATA script block');
+        assert.ok(svg.includes(']]></script>'),      'missing CDATA closing');
+    });
+
+    test('embedded script contains key runtime functions', () => {
+        const svg = generateInteractiveSVG(simpleHierarchy, 'cpu');
+        for (const fn of ['doLayout', 'colorFor', 'render', 'applySearch', 'findAncestors']) {
+            assert.ok(svg.includes(`function ${fn}`), `missing function ${fn}`);
+        }
+    });
+});
+
+// ── Frames ────────────────────────────────────────────────────────────────────
+
+suite('generateInteractiveSVG — frames', () => {
+    test('generates a frame element for every node in the hierarchy', () => {
+        const svg = generateInteractiveSVG(simpleHierarchy, 'cpu');
+        // root + 2 children = 3 frames
+        const frameCount = countOccurrences(svg, 'class="frame"');
+        assert.strictEqual(frameCount, 3);
+    });
+
+    test('each frame has a rect, text, and title child', () => {
+        const svg = generateInteractiveSVG(simpleHierarchy, 'cpu');
+        assert.strictEqual(countOccurrences(svg, 'class="frame"'), countOccurrences(svg, '<title>'));
+        assert.ok(countOccurrences(svg, '<rect id="r') >= 3, 'expected rect per frame');
+        assert.ok(countOccurrences(svg, '<text id="t') >= 3, 'expected text per frame');
+    });
+
+    test('each frame has a matching clip path', () => {
+        const svg = generateInteractiveSVG(simpleHierarchy, 'cpu');
+        assert.strictEqual(
+            countOccurrences(svg, '<clipPath id="c'),
+            countOccurrences(svg, 'class="frame"'),
+            'clip path count should match frame count'
+        );
+    });
+
+    test('frame title contains function name and formatted metric', () => {
+        const svg = generateInteractiveSVG(simpleHierarchy, 'cpu');
+        assert.ok(svg.includes('func_a'), 'expected func_a in output');
+        assert.ok(svg.includes('func_b'), 'expected func_b in output');
+    });
+
+    test('frame title escapes XML special characters', () => {
+        const evil = {
+            key: 'root', name: '<root>', value: 100, children: [], data: { name: '<root>', file: 'a.py' },
+        };
+        const svg = generateInteractiveSVG(evil, 'cpu');
+        assert.ok(!svg.includes('<<root>>'),       'raw angle brackets must be escaped');
+        assert.ok(svg.includes('&lt;root&gt;'), 'expected escaped form');
+    });
+});
+
+// ── Text visibility ───────────────────────────────────────────────────────────
+
+suite('generateInteractiveSVG — text visibility', () => {
+    test('wide frames do not suppress their label', () => {
+        // big_func is 99% of width = ~1188 px > LABEL_MIN_W (30)
+        const svg = generateInteractiveSVG(hierWithNarrowFrame, 'cpu');
+        // Find the text element for big_func — its id is "t" + the _id of big_func.
+        // We can verify no text for big_func carries display="none" while having big_func content.
+        const textBlocks = svg.match(/<text id="t\d+"[^>]*>big_func[^<]*/g) || [];
+        assert.ok(textBlocks.length > 0, 'expected at least one text block for big_func');
+        for (const block of textBlocks) {
+            assert.ok(!block.includes('display="none"'), `wide frame label should be visible: ${block}`);
+        }
+    });
+
+    test('narrow frames suppress their label with display="none"', () => {
+        // tiny_func is 1% of 1200 px = 12 px < LABEL_MIN_W (30)
+        const svg = generateInteractiveSVG(hierWithNarrowFrame, 'cpu');
+        const textBlocks = svg.match(/<text id="t\d+"[^>]*>tiny_func[^<]*/g) || [];
+        assert.ok(textBlocks.length > 0, 'expected at least one text block for tiny_func');
+        for (const block of textBlocks) {
+            assert.ok(block.includes('display="none"'), `narrow frame label should be hidden: ${block}`);
+        }
+    });
+});
+
+// ── Embedded data ─────────────────────────────────────────────────────────────
+
+suite('generateInteractiveSVG — embedded data', () => {
+    test('fg-data element contains valid base64-encoded JSON', () => {
+        const svg = generateInteractiveSVG(simpleHierarchy, 'cpu');
+        assert.doesNotThrow(() => decodeEmbeddedData(svg), 'data blob must decode to valid JSON');
+    });
+
+    test('embedded data preserves the hierarchy structure', () => {
+        const svg = generateInteractiveSVG(simpleHierarchy, 'cpu');
+        const { hierarchy } = decodeEmbeddedData(svg);
+        assert.strictEqual(hierarchy.name, 'root');
+        assert.strictEqual(hierarchy.value, 1000);
+        assert.strictEqual(hierarchy.children.length, 2);
+    });
+
+    test('embedded data carries the correct mode', () => {
+        for (const mode of ['cpu', 'wall', 'memory']) {
+            const svg = generateInteractiveSVG(simpleHierarchy, mode);
+            const { mode: embeddedMode } = decodeEmbeddedData(svg);
+            assert.strictEqual(embeddedMode, mode);
+        }
+    });
+
+    test('all nodes in embedded data have a stable _id', () => {
+        const svg = generateInteractiveSVG(simpleHierarchy, 'cpu');
+        const { hierarchy } = decodeEmbeddedData(svg);
+        function checkIds(node: any): void {
+            assert.ok(typeof node._id === 'number', `node "${node.name}" missing _id`);
+            if (node.children) { node.children.forEach(checkIds); }
+        }
+        checkIds(hierarchy);
+    });
+
+    test('_id values are unique across all nodes', () => {
+        const svg = generateInteractiveSVG(simpleHierarchy, 'cpu');
+        const { hierarchy } = decodeEmbeddedData(svg);
+        const ids: number[] = [];
+        function collect(node: any): void {
+            ids.push(node._id);
+            if (node.children) { node.children.forEach(collect); }
+        }
+        collect(hierarchy);
+        assert.strictEqual(new Set(ids).size, ids.length, '_id values must be unique');
+    });
+});
+
+// ── Mode-specific output ──────────────────────────────────────────────────────
+
+suite('generateInteractiveSVG — modes', () => {
+    test('cpu mode contains "CPU Time Profile" label', () => {
+        const svg = generateInteractiveSVG(simpleHierarchy, 'cpu');
+        assert.ok(svg.includes('CPU Time Profile'), 'missing CPU label');
+    });
+
+    test('wall mode contains "Wall Time Profile" label', () => {
+        const svg = generateInteractiveSVG(simpleHierarchy, 'wall');
+        assert.ok(svg.includes('Wall Time Profile'), 'missing wall label');
+    });
+
+    test('memory mode contains "Memory Allocations Profile" label', () => {
+        const svg = generateInteractiveSVG(simpleHierarchy, 'memory');
+        assert.ok(svg.includes('Memory Allocations Profile'), 'missing memory label');
+    });
+
+    test('different modes produce different background colors', () => {
+        const cpuSvg    = generateInteractiveSVG(simpleHierarchy, 'cpu');
+        const wallSvg   = generateInteractiveSVG(simpleHierarchy, 'wall');
+        const memorySvg = generateInteractiveSVG(simpleHierarchy, 'memory');
+        // Extract the background style value and confirm they differ
+        const bg = (svg: string) => svg.match(/background:([^;]+);/)?.[1];
+        assert.notStrictEqual(bg(cpuSvg),    bg(wallSvg),   'cpu and wall should have different backgrounds');
+        assert.notStrictEqual(bg(cpuSvg),    bg(memorySvg), 'cpu and memory should have different backgrounds');
+        assert.notStrictEqual(bg(wallSvg),   bg(memorySvg), 'wall and memory should have different backgrounds');
+    });
+});
+
+// ── Logo embedding ────────────────────────────────────────────────────────────
+
+suite('generateInteractiveSVG — logo', () => {
+    test('no logo element when logoB64 is omitted', () => {
+        const svg = generateInteractiveSVG(simpleHierarchy, 'cpu');
+        assert.ok(!svg.includes('<image '), 'unexpected <image> element without logo');
+    });
+
+    test('includes <image> element when logoB64 is provided', () => {
+        const fakeB64 = Buffer.from('<svg/>').toString('base64');
+        const svg = generateInteractiveSVG(simpleHierarchy, 'cpu', fakeB64);
+        assert.ok(svg.includes('<image '), 'expected <image> element with logo');
+        assert.ok(svg.includes('data:image/svg+xml;base64,'), 'expected data URI for logo');
+        assert.ok(svg.includes(fakeB64), 'expected encoded logo data in output');
+    });
+
+    test('mode label is shifted right when logo is present', () => {
+        const fakeB64 = Buffer.from('<svg/>').toString('base64');
+        const svgWith    = generateInteractiveSVG(simpleHierarchy, 'cpu', fakeB64);
+        const svgWithout = generateInteractiveSVG(simpleHierarchy, 'cpu');
+        // Match the opening tag of the text element that contains the mode label
+        const labelTag = (svg: string) => svg.match(/<text [^>]*>CPU Time Profile/)?.[0] ?? '';
+        assert.ok(labelTag(svgWith).includes('x="32"'),  'label x should be 32 with logo');
+        assert.ok(labelTag(svgWithout).includes('x="8"'), 'label x should be 8 without logo');
+    });
+});


### PR DESCRIPTION
We add a share button to the flamegraph view to allow sharing an interactive SVG version of the flamegraph. This can be attached e.g. to PR descriptions or comments.