### PR TITLE
chore: improve top and call stacks views UX

### DIFF
--- a/media/callstack.js
+++ b/media/callstack.js
@@ -321,6 +321,10 @@
         if (treeData) { render(); }
     });
 
+    document.getElementById('open-btn').addEventListener('click', () => {
+        vscode.postMessage('open');
+    });
+
     document.querySelectorAll('th[data-col]').forEach(th => {
         th.addEventListener('click', () => {
             const col = th.dataset.col;

--- a/media/top.js
+++ b/media/top.js
@@ -8,6 +8,8 @@
     let expanded = new Set();
     let expandedKeys = new Set();
     let idCounter = 0;
+    const COLLAPSE_MS = 110;
+    const collapseTimers = new WeakMap();
 
     const loading     = document.getElementById('loading');
     const filterInput = document.getElementById('filter-input');
@@ -114,7 +116,13 @@
         tr.dataset.rowId = rowId;
         tr.dataset.level = '0';
         tr.dataset.callerKey = item.key;
-        if (hasCallers) { tr.dataset.expandable = '1'; }
+        if (hasCallers) {
+            tr.dataset.expandable = '1';
+            const n = item.callers.length;
+            tr.title = `${n} caller${n === 1 ? '' : 's'}` + (item.module ? ` · ${item.module}` : '');
+        } else {
+            tr.title = 'no callers detected' + (item.module ? ` · ${item.module}` : '');
+        }
         tr.innerHTML =
             numCell(item.own, 'own', fmt(item.own)) +
             numCell(item.total, 'total', fmt(item.total)) +
@@ -143,6 +151,7 @@
             tr.dataset.callerKey = caller.key;
             if (hasCallers) { tr.dataset.expandable = '1'; }
             if (caller.callersPending) { tr.dataset.callersPending = '1'; }
+            if (caller.module) { tr.title = caller.module; }
             tr.style.display = 'none';
             tr.innerHTML =
                 contribCell(caller.contribution, fmt(caller.contribution)) +
@@ -180,7 +189,12 @@
                 return;
             }
             document.querySelectorAll(`tr[data-parent-id="${rowId}"]`).forEach(tr => {
+                const timer = collapseTimers.get(tr);
+                if (timer !== undefined) { clearTimeout(timer); collapseTimers.delete(tr); }
+                tr.classList.remove('collapsing');
                 tr.style.display = '';
+                tr.classList.add('expanding');
+                tr.addEventListener('animationend', () => tr.classList.remove('expanding'), { once: true });
             });
             expanded.add(rowId);
             if (row) {
@@ -241,6 +255,7 @@
         tr.dataset.callerKey = caller.key;
         if (hasCallers) { tr.dataset.expandable = '1'; }
         if (caller.callersPending) { tr.dataset.callersPending = '1'; }
+        if (caller.module) { tr.title = caller.module; }
         tr.style.display = 'none';
         tr.innerHTML =
             contribCell(caller.contribution, fmt(caller.contribution)) +
@@ -263,7 +278,6 @@
 
     function collapseDescendants(rowId) {
         document.querySelectorAll(`tr[data-parent-id="${rowId}"]`).forEach(tr => {
-            tr.style.display = 'none';
             const childId = tr.dataset.rowId;
             if (expanded.has(childId)) {
                 collapseDescendants(childId);
@@ -271,6 +285,15 @@
                 delete tr.dataset.open;
             }
             if (tr.dataset.callerKey) { expandedKeys.delete(tr.dataset.callerKey); }
+            if (tr.style.display === 'none') { return; }
+            tr.classList.remove('expanding');
+            tr.classList.add('collapsing');
+            const timer = setTimeout(() => {
+                tr.style.display = 'none';
+                tr.classList.remove('collapsing');
+                collapseTimers.delete(tr);
+            }, COLLAPSE_MS);
+            collapseTimers.set(tr, timer);
         });
     }
 
@@ -301,8 +324,8 @@
         const indent = level * 10;
         const mod = module ? basename(module) : '';
         return `<td class="func" style="padding-left:${indent + 6}px">` +
-            `<span class="scope-name" title="${esc(scope)}">${esc(scope || '')}</span>` +
-            (mod ? `<span class="scope-module" title="${esc(module)}">${esc(mod)}</span>` : '') +
+            `<span class="scope-name">${esc(scope || '')}</span>` +
+            (mod ? `<span class="scope-module">${esc(mod)}</span>` : '') +
             `</td>`;
     }
 
@@ -335,6 +358,10 @@
 
     document.getElementById('collapse-all').addEventListener('click', () => {
         if (data.length > 0) { render(); }
+    });
+
+    document.getElementById('open-btn').addEventListener('click', () => {
+        vscode.postMessage('open');
     });
 
     filterInput.addEventListener('input', e => {

--- a/src/providers/callstack.ts
+++ b/src/providers/callstack.ts
@@ -70,6 +70,10 @@ export class CallStackViewProvider implements vscode.WebviewViewProvider {
                 if (this._stats) { this._postData(this._stats); }
                 return;
             }
+            if (data === 'open') {
+                vscode.commands.executeCommand('austin-vscode.load');
+                return;
+            }
             if (data.module) {
                 vscode.commands.executeCommand('austin-vscode.openSourceAtLine', data.module, data.line || 0);
             }
@@ -281,6 +285,20 @@ export class CallStackViewProvider implements vscode.WebviewViewProvider {
             text-align: center;
             font-style: italic;
         }
+        .open-btn {
+            display: block;
+            margin: 10px auto 0;
+            padding: 4px 14px;
+            background: var(--vscode-button-background);
+            color: var(--vscode-button-foreground);
+            border: none;
+            border-radius: 2px;
+            cursor: pointer;
+            font-size: 11px;
+            font-weight: 600;
+            letter-spacing: 0.06em;
+        }
+        .open-btn:hover { background: var(--vscode-button-hoverBackground); }
         #loading {
             display: none;
             position: fixed;
@@ -319,7 +337,10 @@ export class CallStackViewProvider implements vscode.WebviewViewProvider {
         </button>
         <span id="live-dot" title="Live session active"></span>
     </div>
-    <div id="empty" class="empty">No profiling data loaded.</div>
+    <div id="empty" class="empty">
+        <div>No profiling data loaded.</div>
+        <button class="open-btn" id="open-btn">OPEN</button>
+    </div>
     <table id="table" style="display:none">
         <colgroup>
             <col>

--- a/src/providers/top.ts
+++ b/src/providers/top.ts
@@ -56,6 +56,10 @@ export class TopViewProvider implements vscode.WebviewViewProvider {
                 }
                 return;
             }
+            if (data === 'open') {
+                vscode.commands.executeCommand('austin-vscode.load');
+                return;
+            }
             if (data.module !== undefined) {
                 vscode.commands.executeCommand('austin-vscode.openSourceAtLine', data.module, data.line || 0);
             }
@@ -212,10 +216,10 @@ export class TopViewProvider implements vscode.WebviewViewProvider {
         .caller-row:hover > td { background: var(--vscode-list-hoverBackground); }
         .top-row[data-expandable]:hover > td,
         .caller-row[data-expandable]:hover > td { background: var(--vscode-list-hoverBackground); }
-        .top-row[data-open] > td,
-        .caller-row[data-open] > td {
+        .top-row[data-open] > td {
             background: var(--vscode-list-inactiveSelectionBackground, rgba(128,128,128,0.08));
             border-bottom-color: transparent;
+            padding-bottom: 7px;
         }
         col.func  { width: 100%; }
         .bar-row { display: flex; align-items: center; gap: 4px; }
@@ -253,7 +257,21 @@ export class TopViewProvider implements vscode.WebviewViewProvider {
         .caller-row > td {
             font-size: 0.9em;
             border-bottom-color: transparent;
+            background: rgba(128,128,128,0.14);
         }
+        .caller-row:not([style*="none"]) + .top-row > td {
+            border-top: 2px solid var(--vscode-panel-border, rgba(128,128,128,0.25));
+        }
+        @keyframes callerExpandIn {
+            from { opacity: 0; transform: translateY(-6px); }
+            to   { opacity: 1; transform: translateY(0); }
+        }
+        @keyframes callerCollapseOut {
+            from { opacity: 1; transform: translateY(0); }
+            to   { opacity: 0; transform: translateY(-4px); }
+        }
+        .caller-row.expanding  { animation: callerExpandIn   0.14s ease; }
+        .caller-row.collapsing { animation: callerCollapseOut 0.11s ease forwards; }
         /* depth guide lines: left border on the func cell steps in per level */
         .caller-row .func {
             border-left: 1px solid var(--vscode-panel-border, rgba(128,128,128,0.3));
@@ -345,6 +363,20 @@ export class TopViewProvider implements vscode.WebviewViewProvider {
             text-align: center;
             font-style: italic;
         }
+        .open-btn {
+            display: block;
+            margin: 10px auto 0;
+            padding: 4px 14px;
+            background: var(--vscode-button-background);
+            color: var(--vscode-button-foreground);
+            border: none;
+            border-radius: 2px;
+            cursor: pointer;
+            font-size: 11px;
+            font-weight: 600;
+            letter-spacing: 0.06em;
+        }
+        .open-btn:hover { background: var(--vscode-button-hoverBackground); }
         #loading {
             display: none;
             position: fixed;
@@ -387,7 +419,10 @@ export class TopViewProvider implements vscode.WebviewViewProvider {
         </button>
         <span id="live-dot" title="Live session active"></span>
     </div>
-    <div id="empty" class="empty">No profiling data loaded.</div>
+    <div id="empty" class="empty">
+        <div>No profiling data loaded.</div>
+        <button class="open-btn" id="open-btn">OPEN</button>
+    </div>
     <table id="table" style="display:none">
         <colgroup>
             <col class="own">


### PR DESCRIPTION
- Add OPEN button to the empty state of both views so users can load a profile without switching to the flamegraph panel; the button disappears automatically once data is loaded
- Show caller count (and full module path) in the row hover tooltip for top-level entries; show "no callers detected" when there are none
- Remove redundant inner title attributes from function cells so the row-level tooltip is visible everywhere
- Give caller rows a darker background to visually distinguish the expanded section from top-level entries
- Add padding below the parent row and a border above the next entry to create a clear margin around expanded groups
- Animate caller rows on expand (fade + slide in) and collapse (fade + slide out) with a WeakMap-based timer to cancel in-flight animations on rapid toggle