### PR TITLE
feat: fix variable substitution in Austin task definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,12 @@
 - Collapse-all buttons in the call stacks and top panels now correctly reset
   all expanded state before re-rendering.
 
+- Fixed variable substitution in Austin task definitions. Previously, only
+  `${file}` and `${workspaceFolder}` were resolved; all other variables
+  (including `${input:…}`, `${env:NAME}`, and `${cwd}`) were passed literally
+  to the profiled process. All standard VS Code task variables are now
+  supported.
+
 ## [0.17.3]
 
 - - Fixed regression for support for paths with spaces in Austin tasks.

--- a/src/providers/executor.ts
+++ b/src/providers/executor.ts
@@ -14,21 +14,6 @@ function maybeEnquote(arg: string): string {
   return arg.indexOf(' ') >= 0 ? `"${arg}"` : arg;
 }
 
-
-function resolveArgs(args: string[]): string[] {
-  const resolvedArgs: string[] = [];
-  args.forEach((arg) => {
-    if (arg.indexOf("${workspaceFolder}") >= 0 && vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length === 1) {
-      resolvedArgs.push(arg.replace("${workspaceFolder}", vscode.workspace.workspaceFolders[0].uri.fsPath));
-    } else if (arg.indexOf("${file}") >= 0 && vscode.window.activeTextEditor) {
-      resolvedArgs.push(arg.replace("${file}", vscode.window.activeTextEditor.document.fileName));
-    } else {
-      resolvedArgs.push(arg);
-    }
-  });
-  return resolvedArgs;
-}
-
 export class AustinCommandExecutor implements vscode.Pseudoterminal {
   private austinProcess: ChildProcess | undefined;
   private _killed: boolean = false;
@@ -51,7 +36,7 @@ export class AustinCommandExecutor implements vscode.Pseudoterminal {
 
   open(initialDimensions: vscode.TerminalDimensions | undefined): void {
     this.writeEmitter.fire(`Starting Profiler in ${this.cwd}.\r\n`);
-    let resolvedArgs = resolveArgs(this.command.args);
+    const resolvedArgs = this.command.args;
 
     let env: DotenvPopulateInput = {};
     for (let key in process.env) {

--- a/src/providers/task.ts
+++ b/src/providers/task.ts
@@ -5,6 +5,7 @@ import { AustinStats } from "../model";
 import { isPythonExtensionAvailable } from "../utils/pythonExtension";
 import { AustinMode } from "../types";
 import { AustinRuntimeSettings } from "../settings";
+import { resolveVariable, resolveVariables } from "../utils/variableResolver";
 import { isAbsolute } from "path";
 import { platform } from "os";
 
@@ -79,17 +80,24 @@ export class AustinProfileTaskProvider implements vscode.TaskProvider {
           cwd = vscode.workspace.getWorkspaceFolder(vscode.window.activeTextEditor.document.uri)?.uri.fsPath;
         }
 
+        const resolvedFile = definition.file
+          ? await resolveVariable(definition.file, cwd)
+          : undefined;
+        const resolvedArgs = definition.args
+          ? await resolveVariables(definition.args, cwd)
+          : undefined;
+
         let resolvedPath: vscode.Uri | undefined = undefined;
-        if (definition.file) {
-          resolvedPath = isAbsolute(definition.file)
-            ? vscode.Uri.file(definition.file)
-            : vscode.Uri.joinPath(vscode.Uri.file(cwd!), definition.file);
+        if (resolvedFile) {
+          resolvedPath = isAbsolute(resolvedFile)
+            ? vscode.Uri.file(resolvedFile)
+            : vscode.Uri.joinPath(vscode.Uri.file(cwd!), resolvedFile);
         }
 
         const command = getAustinCommand(
           resolvedPath?.fsPath,
           definition.command,
-          definition.args,
+          resolvedArgs,
           definition.austinArgs,
           definition.interval,
           definition.mode,

--- a/src/test/suite/variableResolver.test.ts
+++ b/src/test/suite/variableResolver.test.ts
@@ -1,0 +1,275 @@
+import * as assert from 'assert';
+import { resolveVariable, resolveVariables } from '../../utils/variableResolver';
+
+const vscode = require('vscode');
+
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function withWorkspaceFolder(fsPath: string, fn: () => Promise<void>): Promise<void> {
+    const original = vscode.workspace.workspaceFolders;
+    vscode.workspace.workspaceFolders = [{ uri: { fsPath } }];
+    return fn().finally(() => { vscode.workspace.workspaceFolders = original; });
+}
+
+function withActiveFile(fileName: string, fn: () => Promise<void>): Promise<void> {
+    const descriptor = Object.getOwnPropertyDescriptor(vscode.window, 'activeTextEditor');
+    Object.defineProperty(vscode.window, 'activeTextEditor', {
+        get: () => ({ document: { fileName } }),
+        configurable: true,
+    });
+    return fn().finally(() => {
+        Object.defineProperty(vscode.window, 'activeTextEditor', descriptor!);
+    });
+}
+
+function withTaskInputs(inputs: unknown[], fn: () => Promise<void>): Promise<void> {
+    const original = vscode.workspace.getConfiguration;
+    vscode.workspace.getConfiguration = (section: string) => {
+        if (section === 'tasks') {
+            return { get: (key: string) => key === 'inputs' ? inputs : undefined };
+        }
+        return original(section);
+    };
+    return fn().finally(() => { vscode.workspace.getConfiguration = original; });
+}
+
+
+// ---------------------------------------------------------------------------
+// ${workspaceFolder}
+// ---------------------------------------------------------------------------
+suite('resolveVariable — ${workspaceFolder}', () => {
+
+    test('substitutes when there is exactly one workspace folder', async () => {
+        await withWorkspaceFolder('/workspace', async () => {
+            assert.strictEqual(
+                await resolveVariable('${workspaceFolder}/src/main.py'),
+                '/workspace/src/main.py',
+            );
+        });
+    });
+
+    test('substitutes all occurrences', async () => {
+        await withWorkspaceFolder('/ws', async () => {
+            assert.strictEqual(
+                await resolveVariable('${workspaceFolder} and ${workspaceFolder}'),
+                '/ws and /ws',
+            );
+        });
+    });
+
+    test('leaves token unchanged when no workspace folder is set', async () => {
+        const original = vscode.workspace.workspaceFolders;
+        vscode.workspace.workspaceFolders = undefined;
+        try {
+            assert.strictEqual(
+                await resolveVariable('${workspaceFolder}/main.py'),
+                '${workspaceFolder}/main.py',
+            );
+        } finally {
+            vscode.workspace.workspaceFolders = original;
+        }
+    });
+
+    test('leaves token unchanged when multiple workspace folders are present', async () => {
+        const original = vscode.workspace.workspaceFolders;
+        vscode.workspace.workspaceFolders = [
+            { uri: { fsPath: '/ws1' } },
+            { uri: { fsPath: '/ws2' } },
+        ];
+        try {
+            assert.strictEqual(
+                await resolveVariable('${workspaceFolder}/main.py'),
+                '${workspaceFolder}/main.py',
+            );
+        } finally {
+            vscode.workspace.workspaceFolders = original;
+        }
+    });
+});
+
+
+// ---------------------------------------------------------------------------
+// ${cwd}
+// ---------------------------------------------------------------------------
+suite('resolveVariable — ${cwd}', () => {
+
+    test('substitutes the provided cwd', async () => {
+        assert.strictEqual(
+            await resolveVariable('${cwd}/main.py', '/project'),
+            '/project/main.py',
+        );
+    });
+
+    test('substitutes all occurrences', async () => {
+        assert.strictEqual(
+            await resolveVariable('${cwd} + ${cwd}', '/proj'),
+            '/proj + /proj',
+        );
+    });
+
+    test('leaves token unchanged when cwd is not provided', async () => {
+        assert.strictEqual(
+            await resolveVariable('${cwd}/main.py'),
+            '${cwd}/main.py',
+        );
+    });
+});
+
+
+// ---------------------------------------------------------------------------
+// ${file}
+// ---------------------------------------------------------------------------
+suite('resolveVariable — ${file}', () => {
+
+    test('substitutes the active editor file path', async () => {
+        await withActiveFile('/project/src/main.py', async () => {
+            assert.strictEqual(
+                await resolveVariable('${file}'),
+                '/project/src/main.py',
+            );
+        });
+    });
+
+    test('leaves token unchanged when no editor is active', async () => {
+        assert.strictEqual(
+            await resolveVariable('${file}'),
+            '${file}',
+        );
+    });
+});
+
+
+// ---------------------------------------------------------------------------
+// ${env:NAME}
+// ---------------------------------------------------------------------------
+suite('resolveVariable — ${env:NAME}', () => {
+
+    test('substitutes a set environment variable', async () => {
+        process.env['__AUSTIN_TEST_VAR__'] = 'hello';
+        try {
+            assert.strictEqual(
+                await resolveVariable('--arg=${env:__AUSTIN_TEST_VAR__}'),
+                '--arg=hello',
+            );
+        } finally {
+            delete process.env['__AUSTIN_TEST_VAR__'];
+        }
+    });
+
+    test('substitutes an empty string for an unset variable', async () => {
+        delete process.env['__AUSTIN_MISSING__'];
+        assert.strictEqual(
+            await resolveVariable('${env:__AUSTIN_MISSING__}'),
+            '',
+        );
+    });
+
+    test('substitutes multiple distinct env vars in one string', async () => {
+        process.env['__AUSTIN_A__'] = 'foo';
+        process.env['__AUSTIN_B__'] = 'bar';
+        try {
+            assert.strictEqual(
+                await resolveVariable('${env:__AUSTIN_A__}/${env:__AUSTIN_B__}'),
+                'foo/bar',
+            );
+        } finally {
+            delete process.env['__AUSTIN_A__'];
+            delete process.env['__AUSTIN_B__'];
+        }
+    });
+});
+
+
+// ---------------------------------------------------------------------------
+// ${input:NAME}
+// ---------------------------------------------------------------------------
+suite('resolveVariable — ${input:NAME}', () => {
+
+    test('resolves a promptString input', async () => {
+        const inputs = [{ id: 'myInput', type: 'promptString', description: 'Enter value' }];
+        await withTaskInputs(inputs, async () => {
+            vscode.window.showInputBox = async () => 'typed-value';
+            const result = await resolveVariable('--flag=${input:myInput}');
+            assert.strictEqual(result, '--flag=typed-value');
+        });
+    });
+
+    test('resolves a pickString input', async () => {
+        const inputs = [{ id: 'myPick', type: 'pickString', options: ['a', 'b', 'c'] }];
+        await withTaskInputs(inputs, async () => {
+            vscode.window.showQuickPick = async () => 'b';
+            const result = await resolveVariable('${input:myPick}');
+            assert.strictEqual(result, 'b');
+        });
+    });
+
+    test('resolves a command input', async () => {
+        const inputs = [{ id: 'myCmd', type: 'command', command: 'extension.myCommand' }];
+        await withTaskInputs(inputs, async () => {
+            vscode.commands = { executeCommand: async () => 'cmd-result' };
+            const result = await resolveVariable('${input:myCmd}');
+            assert.strictEqual(result, 'cmd-result');
+        });
+    });
+
+    test('leaves token unchanged when input id is not found', async () => {
+        await withTaskInputs([], async () => {
+            const result = await resolveVariable('${input:unknown}');
+            assert.strictEqual(result, '${input:unknown}');
+        });
+    });
+
+    test('leaves token unchanged when no inputs are configured', async () => {
+        const result = await resolveVariable('${input:whatever}');
+        assert.strictEqual(result, '${input:whatever}');
+    });
+});
+
+
+// ---------------------------------------------------------------------------
+// Mixed variables and resolveVariables
+// ---------------------------------------------------------------------------
+suite('resolveVariable — mixed', () => {
+
+    test('resolves multiple variable types in a single string', async () => {
+        process.env['__AUSTIN_MIX__'] = 'envval';
+        try {
+            await withWorkspaceFolder('/ws', async () => {
+                assert.strictEqual(
+                    await resolveVariable('${workspaceFolder}/${env:__AUSTIN_MIX__}', '/ws'),
+                    '/ws/envval',
+                );
+            });
+        } finally {
+            delete process.env['__AUSTIN_MIX__'];
+        }
+    });
+
+    test('passes through plain strings unchanged', async () => {
+        assert.strictEqual(await resolveVariable('no-variables-here'), 'no-variables-here');
+    });
+});
+
+suite('resolveVariables', () => {
+
+    test('resolves each element independently', async () => {
+        process.env['__AUSTIN_V1__'] = 'x';
+        process.env['__AUSTIN_V2__'] = 'y';
+        try {
+            const result = await resolveVariables(
+                ['${env:__AUSTIN_V1__}', '${env:__AUSTIN_V2__}', 'plain'],
+            );
+            assert.deepStrictEqual(result, ['x', 'y', 'plain']);
+        } finally {
+            delete process.env['__AUSTIN_V1__'];
+            delete process.env['__AUSTIN_V2__'];
+        }
+    });
+
+    test('returns an empty array for an empty input', async () => {
+        assert.deepStrictEqual(await resolveVariables([]), []);
+    });
+});

--- a/src/test/vscode-mock.ts
+++ b/src/test/vscode-mock.ts
@@ -30,8 +30,13 @@ const mock = {
     window: {
         showErrorMessage: () => undefined,
         showInformationMessage: () => undefined,
+        showInputBox: () => Promise.resolve(undefined),
+        showQuickPick: () => Promise.resolve(undefined),
         get activeTextEditor() { return undefined; },
         createTextEditorDecorationType: () => ({ dispose: () => undefined }),
+    },
+    commands: {
+        executeCommand: () => Promise.resolve(undefined),
     },
     Uri: {
         joinPath: (base: { fsPath: string }, ...parts: string[]) => ({

--- a/src/utils/variableResolver.ts
+++ b/src/utils/variableResolver.ts
@@ -1,0 +1,71 @@
+import * as vscode from "vscode";
+
+
+async function resolveInputVariable(name: string): Promise<string | undefined> {
+    const inputs: any[] = vscode.workspace.getConfiguration("tasks").get("inputs") ?? [];
+    const input = inputs.find((i) => i.id === name);
+    if (!input) { return undefined; }
+
+    if (input.type === "pickString") {
+        return vscode.window.showQuickPick(input.options ?? [], {
+            placeHolder: input.description,
+        });
+    } else if (input.type === "promptString") {
+        return vscode.window.showInputBox({
+            prompt: input.description,
+            password: input.password === true,
+            value: input.default,
+        });
+    } else if (input.type === "command") {
+        return vscode.commands.executeCommand<string>(input.command, input.args);
+    }
+
+    return undefined;
+}
+
+
+export async function resolveVariable(value: string, cwd?: string): Promise<string> {
+    if (value.includes("${workspaceFolder}")) {
+        const folders = vscode.workspace.workspaceFolders;
+        if (folders?.length === 1) {
+            value = value.replace(/\$\{workspaceFolder\}/g, folders[0].uri.fsPath);
+        }
+    }
+
+    if (value.includes("${cwd}") && cwd) {
+        value = value.replace(/\$\{cwd\}/g, cwd);
+    }
+
+    if (value.includes("${file}") && vscode.window.activeTextEditor) {
+        value = value.replace(/\$\{file\}/g, vscode.window.activeTextEditor.document.fileName);
+    }
+
+    const envPattern = /\$\{env:([^}]+)\}/g;
+    let match: RegExpExecArray | null;
+    while ((match = envPattern.exec(value)) !== null) {
+        const envValue = process.env[match[1]] ?? "";
+        value = value.replace(match[0], envValue);
+        envPattern.lastIndex = 0;
+    }
+
+    const inputPattern = /\$\{input:([^}]+)\}/g;
+    while ((match = inputPattern.exec(value)) !== null) {
+        const resolved = await resolveInputVariable(match[1]);
+        if (resolved !== undefined) {
+            value = value.replace(match[0], resolved);
+            // Reset lastIndex since the string changed
+            inputPattern.lastIndex = 0;
+        }
+    }
+
+    return value;
+}
+
+
+export async function resolveVariables(values: string[], cwd?: string): Promise<string[]> {
+    const resolved: string[] = [];
+    for (const v of values) {
+        resolved.push(await resolveVariable(v, cwd));
+    }
+    return resolved;
+}


### PR DESCRIPTION
Custom task providers using CustomExecution do not benefit from VSCode's built-in variable resolution. Previously only \${file} and \${workspaceFolder} were handled manually; all other variables (\${input:…}, \${env:NAME}, \${cwd}, etc.) were passed literally to the profiled process.

Introduce a variableResolver utility that resolves the full set of standard task variables — including input prompts (pickString, promptString, command), environment variables, and cwd — inside the CustomExecution callback before the austin process is spawned. The now-redundant resolveArgs helper in the executor is removed.

Resolves #72.