### PR TITLE
feat: add MCP server for AI chat integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,15 @@
 
 - Both panels show a sortable **Own** and **Total** column.
 
+### AI Chat Integration
+
+- Added an MCP server that exposes profiling data to AI chat sessions (e.g.
+  Claude Code). The server starts lazily when the first profiling data becomes
+  available and listens on port 7891 by default (configurable via
+  `austin.mcpPort`; set to `0` to disable). Three tools are provided:
+  `get_top`, `get_call_stacks`, and `get_metadata`. See the README for setup
+  instructions.
+
 ### Other Improvements
 
 - Collapse-all buttons in the call stacks and top panels now correctly reset

--- a/README.md
+++ b/README.md
@@ -161,6 +161,46 @@ mode and the extension won't work if in binary mode.
 Python module has multiple methods with the same names (e.g. `__init__`), since
 the function names collected by Austin are not fully qualified. -->
 
+## AI Chat Integration (MCP)
+
+The extension exposes profiling data to AI chat sessions (such as
+[Claude Code](https://claude.ai/code)) via an
+[MCP](https://modelcontextprotocol.io/) server. The server starts lazily the
+first time profiling data becomes available, and stops when the extension
+deactivates.
+
+The server listens on port **7891** by default (configurable via
+`austin.mcpPort`; set to `0` to disable).
+
+To connect Claude Code to the server, add a `.mcp.json` file to your project
+root:
+
+```json
+{
+    "mcpServers": {
+        "austin": {
+            "type": "http",
+            "url": "http://localhost:7891/mcp"
+        }
+    }
+}
+```
+
+> [!NOTE]
+> Adjust the port in the URL if you have changed `austin.mcpPort`.
+
+Once connected, the following tools are available in your chat session:
+
+| Tool | Description |
+|---|---|
+| `get_top` | Top functions by own time. Accepts an optional `limit`. |
+| `get_call_stacks` | Process→thread→function call-stack tree. Accepts an optional `depth` (default: 5). |
+| `get_metadata` | Profiling session metadata: source file, mode, interval, sample count. |
+
+Percentage values are relative to the total observed metric (CPU time, wall
+time, or memory, depending on the profiling mode).
+
+
 ## Configuration
 
 Whenever you have an active Python script, the sampling interval and mode

--- a/package.json
+++ b/package.json
@@ -77,6 +77,11 @@
             "Both percent and absolute metric values"
           ],
           "default": "Percent"
+        },
+        "austin.mcpPort": {
+          "description": "Port for the Austin MCP server, which exposes profiling data to AI chat sessions (e.g. Claude Code). The server starts lazily when the first profiling data becomes available. Set to 0 to disable.",
+          "type": "number",
+          "default": 7891
         }
       }
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,6 +9,7 @@ import { AustinProfileTaskProvider } from './providers/task';
 import { AustinRuntimeSettings } from './settings';
 import { AustinMode } from './types';
 import { AUSTIN_MIN_MAJOR, AustinVersionError, checkAustinVersion } from './utils/versionCheck';
+import { AustinMcpServer } from './providers/mcp';
 
 
 export function activate(context: vscode.ExtensionContext) {
@@ -17,6 +18,13 @@ export function activate(context: vscode.ExtensionContext) {
 	});
 
 	const stats = new AustinStats();
+
+	const mcpPort = AustinRuntimeSettings.getMcpPort();
+	if (mcpPort > 0) {
+		const mcpServer = new AustinMcpServer(mcpPort);
+		stats.registerAfterCallback((s) => mcpServer.update(s));
+		context.subscriptions.push({ dispose: () => mcpServer.dispose() });
+	}
 
 	context.subscriptions.push(
 		vscode.window.onDidChangeActiveTextEditor((editor) => {

--- a/src/providers/mcp.ts
+++ b/src/providers/mcp.ts
@@ -1,0 +1,261 @@
+import * as http from 'http';
+import * as vscode from 'vscode';
+import { AustinStats, TopStats } from '../model';
+
+const MCP_PROTOCOL_VERSION = '2024-11-05';
+const SERVER_NAME = 'austin-vscode';
+const SERVER_VERSION = '1.0.0';
+
+// ---------------------------------------------------------------------------
+// Tool definitions (static, sent in tools/list responses)
+// ---------------------------------------------------------------------------
+const TOOLS = [
+    {
+        name: 'get_top',
+        description: 'Returns the top functions by own CPU/wall/memory time, sorted descending. Own time is the time spent directly in the function body; total time includes callees.',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                limit: {
+                    type: 'number',
+                    description: 'Maximum number of functions to return. Omit for all.',
+                },
+            },
+            additionalProperties: false,
+        },
+    },
+    {
+        name: 'get_call_stacks',
+        description: 'Returns the process→thread→function call-stack tree. Each node has scope, module, own%, total%, and children.',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                depth: {
+                    type: 'number',
+                    description: 'Maximum tree depth to expand (default: 5).',
+                },
+            },
+            additionalProperties: false,
+        },
+    },
+    {
+        name: 'get_metadata',
+        description: 'Returns profiling session metadata: source file, sampling mode, interval, total sample count, and any other metadata emitted by Austin.',
+        inputSchema: {
+            type: 'object',
+            properties: {},
+            additionalProperties: false,
+        },
+    },
+];
+
+// ---------------------------------------------------------------------------
+// Serialisation helpers
+// ---------------------------------------------------------------------------
+interface CallStackNode {
+    scope: string | null;
+    module: string | null;
+    own: number;
+    total: number;
+    children: CallStackNode[];
+}
+
+function serializeCallStackNode(node: TopStats, depth: number): CallStackNode {
+    return {
+        scope: node.scope,
+        module: node.module,
+        own: parseFloat((node.own * 100).toFixed(2)),
+        total: parseFloat((node.total * 100).toFixed(2)),
+        children: depth > 0
+            ? [...node.callees.values()].map(child => serializeCallStackNode(child, depth - 1))
+            : [],
+    };
+}
+
+// ---------------------------------------------------------------------------
+// AustinMcpServer
+// ---------------------------------------------------------------------------
+export class AustinMcpServer {
+    private _httpServer: http.Server | null = null;
+    private _stats: AustinStats | null = null;
+
+    constructor(private readonly _port: number) { }
+
+    /**
+     * Called on every stats refresh. Starts the HTTP server lazily on the
+     * first call so that the server only runs when profiling data exists.
+     */
+    update(stats: AustinStats): void {
+        this._stats = stats;
+        if (!this._httpServer) {
+            this._startServer();
+        }
+    }
+
+    /** Returns the port the server is actually listening on (0 until started). */
+    get port(): number {
+        const addr = this._httpServer?.address();
+        if (addr && typeof addr === 'object') { return addr.port; }
+        return 0;
+    }
+
+    dispose(): void {
+        this._httpServer?.close();
+        this._httpServer = null;
+        this._stats = null;
+    }
+
+    // -----------------------------------------------------------------------
+    // Private
+    // -----------------------------------------------------------------------
+
+    private _startServer(): void {
+        const server = http.createServer((req, res) => this._handleRequest(req, res));
+
+        server.on('error', (err: NodeJS.ErrnoException) => {
+            if (err.code === 'EADDRINUSE') {
+                vscode.window.showWarningMessage(
+                    `Austin MCP server could not start: port ${this._port} is already in use. ` +
+                    `Change the austin.mcpPort setting to use a different port.`
+                );
+            } else {
+                vscode.window.showWarningMessage(`Austin MCP server error: ${err.message}`);
+            }
+            this._httpServer = null;
+        });
+
+        server.listen(this._port);
+        this._httpServer = server;
+    }
+
+    private _handleRequest(req: http.IncomingMessage, res: http.ServerResponse): void {
+        if (req.method !== 'POST') {
+            res.writeHead(405, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify(this._error(null, -32600, 'Only POST is supported')));
+            return;
+        }
+
+        let body = '';
+        req.on('data', (chunk: Buffer) => { body += chunk.toString(); });
+        req.on('end', () => {
+            let msg: unknown;
+            try {
+                msg = JSON.parse(body);
+            } catch {
+                res.writeHead(400, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify(this._error(null, -32700, 'Parse error')));
+                return;
+            }
+
+            const response = this._dispatch(msg as Record<string, unknown>);
+            if (response === null) {
+                // Notification — no body expected
+                res.writeHead(202);
+                res.end();
+                return;
+            }
+
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify(response));
+        });
+    }
+
+    private _dispatch(msg: Record<string, unknown>): Record<string, unknown> | null {
+        const id = (msg.id ?? null) as string | number | null;
+        const method = msg.method as string | undefined;
+        const params = (msg.params ?? {}) as Record<string, unknown>;
+
+        switch (method) {
+            case 'initialize':
+                return {
+                    jsonrpc: '2.0', id,
+                    result: {
+                        protocolVersion: MCP_PROTOCOL_VERSION,
+                        capabilities: { tools: {} },
+                        serverInfo: { name: SERVER_NAME, version: SERVER_VERSION },
+                    },
+                };
+
+            case 'ping':
+                return { jsonrpc: '2.0', id, result: {} };
+
+            case 'notifications/initialized':
+            case 'notifications/cancelled':
+                return null; // Notifications require no response
+
+            case 'tools/list':
+                return { jsonrpc: '2.0', id, result: { tools: TOOLS } };
+
+            case 'tools/call': {
+                const toolName = params.name as string | undefined;
+                const args = (params.arguments ?? {}) as Record<string, unknown>;
+                if (!toolName) {
+                    return this._error(id, -32602, 'Missing tool name');
+                }
+                const content = this._callTool(toolName, args);
+                return { jsonrpc: '2.0', id, result: { content } };
+            }
+
+            default:
+                return this._error(id, -32601, `Method not found: ${method}`);
+        }
+    }
+
+    private _callTool(name: string, args: Record<string, unknown>): Array<{ type: string; text: string }> {
+        if (!this._stats || this._stats.overallTotal === 0) {
+            return [{ type: 'text', text: 'No profiling data available yet. Run a profiling session first.' }];
+        }
+
+        switch (name) {
+            case 'get_top':
+                return this._getTop(args.limit as number | undefined);
+            case 'get_call_stacks':
+                return this._getCallStacks(args.depth as number | undefined);
+            case 'get_metadata':
+                return this._getMetadata();
+            default:
+                return [{ type: 'text', text: `Unknown tool: ${name}` }];
+        }
+    }
+
+    private _getTop(limit?: number): Array<{ type: string; text: string }> {
+        const stats = this._stats!;
+        const entries = [...stats.top.entries()]
+            .map(([key, s]) => ({
+                key,
+                scope: s.scope,
+                module: s.module,
+                ownPct: parseFloat((s.own * 100).toFixed(2)),
+                totalPct: parseFloat((s.total * 100).toFixed(2)),
+                line: s.minLine,
+            }))
+            .sort((a, b) => b.ownPct - a.ownPct);
+
+        const result = limit != null && limit > 0 ? entries.slice(0, limit) : entries;
+        return [{ type: 'text', text: JSON.stringify(result, null, 2) }];
+    }
+
+    private _getCallStacks(depth: number = 5): Array<{ type: string; text: string }> {
+        const stats = this._stats!;
+        const tree = [...stats.callStack.callees.values()].map(n => serializeCallStackNode(n, depth - 1));
+        return [{ type: 'text', text: JSON.stringify(tree, null, 2) }];
+    }
+
+    private _getMetadata(): Array<{ type: string; text: string }> {
+        const stats = this._stats!;
+        const meta: Record<string, unknown> = {
+            source: stats.source,
+            totalSamples: stats.overallTotal,
+        };
+        for (const [k, v] of stats.metadata) { meta[k] = v; }
+        return [{ type: 'text', text: JSON.stringify(meta, null, 2) }];
+    }
+
+    private _error(
+        id: string | number | null,
+        code: number,
+        message: string,
+    ): Record<string, unknown> {
+        return { jsonrpc: '2.0', id, error: { code, message } };
+    }
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -5,6 +5,7 @@ export const DEFAULT_PATH = "austin";
 export const DEFAULT_INTERVAL = 100;
 export const DEFAULT_MODE = AustinMode.WallTime;
 export const DEFAULT_LINE_STATS = AustinLineStats.PERCENT;
+export const DEFAULT_MCP_PORT = 7891;
 
 export class AustinRuntimeSettings {
     private static config = vscode.workspace.getConfiguration('austin');
@@ -75,5 +76,9 @@ export class AustinRuntimeSettings {
 
     public static setChildren(children: boolean) {
         AustinRuntimeSettings.config.update("children", children, vscode.ConfigurationTarget.Global);
+    }
+
+    public static getMcpPort(): number {
+        return AustinRuntimeSettings.config.get<number>("mcpPort", DEFAULT_MCP_PORT);
     }
 }

--- a/src/test/suite/mcp.test.ts
+++ b/src/test/suite/mcp.test.ts
@@ -1,0 +1,280 @@
+import * as assert from 'assert';
+import * as http from 'http';
+import { Readable } from 'stream';
+import { AustinMcpServer } from '../../providers/mcp';
+import { AustinStats } from '../../model';
+import '../../stringExtension';
+import '../../mapExtension';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function post(port: number, body: unknown): Promise<unknown> {
+    return new Promise((resolve, reject) => {
+        const payload = JSON.stringify(body);
+        const req = http.request(
+            { hostname: '127.0.0.1', port, path: '/mcp', method: 'POST',
+              headers: { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(payload) } },
+            (res) => {
+                let data = '';
+                res.on('data', (chunk: Buffer) => { data += chunk.toString(); });
+                res.on('end', () => {
+                    if (res.statusCode === 202) { resolve(null); return; }
+                    try { resolve(JSON.parse(data)); }
+                    catch (e) { reject(new Error(`Bad JSON: ${data}`)); }
+                });
+            }
+        );
+        req.on('error', reject);
+        req.end(payload);
+    });
+}
+
+function makeStats(lines: string): Promise<AustinStats> {
+    return new Promise((resolve) => {
+        const stats = new AustinStats();
+        stats.registerAfterCallback(() => resolve(stats));
+        const stream = new Readable();
+        stream.push(lines);
+        stream.push(null);
+        stats.readFromStream(stream, 'test.austin');
+    });
+}
+
+function startedServer(stats: AustinStats): AustinMcpServer {
+    const server = new AustinMcpServer(0); // port 0 = OS-assigned
+    server.update(stats);
+    return server;
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+suite('AustinMcpServer', () => {
+
+    let server: AustinMcpServer | null = null;
+
+    teardown(() => {
+        server?.dispose();
+        server = null;
+    });
+
+    // --- Lifecycle ----------------------------------------------------------
+
+    test('server does not start before update() is called', () => {
+        server = new AustinMcpServer(0);
+        assert.strictEqual(server.port, 0);
+    });
+
+    test('server starts lazily on first update() call', async () => {
+        const stats = await makeStats('P1;T1;/a.py:fn:1 100\n');
+        server = startedServer(stats);
+        assert.ok(server.port > 0, 'port should be assigned after update()');
+    });
+
+    test('dispose() stops the server', async () => {
+        const stats = await makeStats('P1;T1;/a.py:fn:1 100\n');
+        server = startedServer(stats);
+        const port = server.port;
+        server.dispose();
+        server = null;
+
+        // After dispose, connections should be refused
+        await assert.rejects(
+            () => post(port, { jsonrpc: '2.0', method: 'ping', id: 1 }),
+            /ECONNREFUSED/
+        );
+    });
+
+    // --- MCP protocol -------------------------------------------------------
+
+    test('initialize returns server info and capabilities', async () => {
+        const stats = await makeStats('P1;T1;/a.py:fn:1 100\n');
+        server = startedServer(stats);
+        const res = await post(server.port, {
+            jsonrpc: '2.0', method: 'initialize', id: 1,
+            params: { protocolVersion: '2024-11-05', clientInfo: { name: 'test', version: '0' }, capabilities: {} },
+        }) as Record<string, unknown>;
+
+        assert.strictEqual(res.jsonrpc, '2.0');
+        assert.strictEqual(res.id, 1);
+        const result = res.result as Record<string, unknown>;
+        assert.ok(result.protocolVersion);
+        assert.ok((result.serverInfo as Record<string, unknown>).name);
+    });
+
+    test('ping returns empty result', async () => {
+        const stats = await makeStats('P1;T1;/a.py:fn:1 100\n');
+        server = startedServer(stats);
+        const res = await post(server.port, { jsonrpc: '2.0', method: 'ping', id: 2 }) as Record<string, unknown>;
+        assert.deepStrictEqual(res.result, {});
+    });
+
+    test('notifications/initialized returns 202 (no body)', async () => {
+        const stats = await makeStats('P1;T1;/a.py:fn:1 100\n');
+        server = startedServer(stats);
+        const res = await post(server.port, { jsonrpc: '2.0', method: 'notifications/initialized' });
+        assert.strictEqual(res, null);
+    });
+
+    test('tools/list returns all three tools', async () => {
+        const stats = await makeStats('P1;T1;/a.py:fn:1 100\n');
+        server = startedServer(stats);
+        const res = await post(server.port, { jsonrpc: '2.0', method: 'tools/list', id: 3 }) as Record<string, unknown>;
+        const tools = (res.result as Record<string, unknown>).tools as Array<{ name: string }>;
+        const names = tools.map(t => t.name);
+        assert.ok(names.includes('get_top'));
+        assert.ok(names.includes('get_call_stacks'));
+        assert.ok(names.includes('get_metadata'));
+    });
+
+    test('unknown method returns error -32601', async () => {
+        const stats = await makeStats('P1;T1;/a.py:fn:1 100\n');
+        server = startedServer(stats);
+        const res = await post(server.port, { jsonrpc: '2.0', method: 'nonexistent', id: 4 }) as Record<string, unknown>;
+        assert.strictEqual((res.error as Record<string, unknown>).code, -32601);
+    });
+
+    test('malformed JSON returns 400', (done) => {
+        makeStats('P1;T1;/a.py:fn:1 100\n').then((stats) => {
+            server = startedServer(stats);
+            const req = http.request(
+                { hostname: '127.0.0.1', port: server!.port, path: '/mcp', method: 'POST',
+                  headers: { 'Content-Type': 'application/json' } },
+                (res) => { assert.strictEqual(res.statusCode, 400); done(); }
+            );
+            req.end('{bad json');
+        });
+    });
+
+    // --- get_top ------------------------------------------------------------
+
+    test('get_top returns functions sorted by own% descending', async () => {
+        const stats = await makeStats(
+            'P1;T1;/a.py:outer:1;/a.py:inner:2 100\n' +
+            'P1;T1;/a.py:outer:1 50\n'
+        );
+        server = startedServer(stats);
+        const res = await post(server.port, {
+            jsonrpc: '2.0', method: 'tools/call', id: 5,
+            params: { name: 'get_top', arguments: {} },
+        }) as Record<string, unknown>;
+
+        const content = (res.result as Record<string, unknown>).content as Array<{ type: string; text: string }>;
+        const rows = JSON.parse(content[0].text) as Array<{ key: string; ownPct: number }>;
+        assert.ok(rows.length >= 2);
+        assert.ok(rows[0].ownPct >= rows[1].ownPct, 'should be sorted descending by ownPct');
+    });
+
+    test('get_top respects limit', async () => {
+        const stats = await makeStats(
+            'P1;T1;/a.py:f1:1 100\n' +
+            'P1;T1;/a.py:f2:2 80\n' +
+            'P1;T1;/a.py:f3:3 60\n'
+        );
+        server = startedServer(stats);
+        const res = await post(server.port, {
+            jsonrpc: '2.0', method: 'tools/call', id: 6,
+            params: { name: 'get_top', arguments: { limit: 2 } },
+        }) as Record<string, unknown>;
+
+        const content = (res.result as Record<string, unknown>).content as Array<{ type: string; text: string }>;
+        const rows = JSON.parse(content[0].text) as unknown[];
+        assert.strictEqual(rows.length, 2);
+    });
+
+    test('get_top includes ownPct, totalPct, scope, module, line fields', async () => {
+        const stats = await makeStats('P1;T1;/a.py:fn:5 200\n');
+        server = startedServer(stats);
+        const res = await post(server.port, {
+            jsonrpc: '2.0', method: 'tools/call', id: 7,
+            params: { name: 'get_top', arguments: {} },
+        }) as Record<string, unknown>;
+
+        const content = (res.result as Record<string, unknown>).content as Array<{ type: string; text: string }>;
+        const rows = JSON.parse(content[0].text) as Array<Record<string, unknown>>;
+        const row = rows[0];
+        assert.ok('ownPct' in row);
+        assert.ok('totalPct' in row);
+        assert.ok('scope' in row);
+        assert.ok('module' in row);
+        assert.ok('line' in row);
+    });
+
+    // --- get_call_stacks ----------------------------------------------------
+
+    test('get_call_stacks returns process/thread/function tree', async () => {
+        const stats = await makeStats('P1;T1;/a.py:fn:1 100\n');
+        server = startedServer(stats);
+        const res = await post(server.port, {
+            jsonrpc: '2.0', method: 'tools/call', id: 8,
+            params: { name: 'get_call_stacks', arguments: {} },
+        }) as Record<string, unknown>;
+
+        const content = (res.result as Record<string, unknown>).content as Array<{ type: string; text: string }>;
+        const tree = JSON.parse(content[0].text) as Array<Record<string, unknown>>;
+        assert.ok(tree.length > 0, 'tree should have at least one process node');
+        const processNode = tree[0] as { children: Array<{ children: unknown[] }> };
+        assert.ok(processNode.children.length > 0, 'process node should have thread children');
+    });
+
+    test('get_call_stacks respects depth=1', async () => {
+        const stats = await makeStats('P1;T1;/a.py:outer:1;/a.py:inner:2 100\n');
+        server = startedServer(stats);
+        const res = await post(server.port, {
+            jsonrpc: '2.0', method: 'tools/call', id: 9,
+            params: { name: 'get_call_stacks', arguments: { depth: 1 } },
+        }) as Record<string, unknown>;
+
+        const content = (res.result as Record<string, unknown>).content as Array<{ type: string; text: string }>;
+        const tree = JSON.parse(content[0].text) as Array<{ children: unknown[] }>;
+        // depth=1: process node shown, its children (threads) have empty children
+        const processNode = tree[0] as { children: Array<{ children: unknown[] }> };
+        assert.strictEqual(processNode.children.length, 0);
+    });
+
+    // --- get_metadata -------------------------------------------------------
+
+    test('get_metadata returns source and totalSamples', async () => {
+        const stats = await makeStats('# mode: wall\nP1;T1;/a.py:fn:1 100\n');
+        server = startedServer(stats);
+        const res = await post(server.port, {
+            jsonrpc: '2.0', method: 'tools/call', id: 10,
+            params: { name: 'get_metadata', arguments: {} },
+        }) as Record<string, unknown>;
+
+        const content = (res.result as Record<string, unknown>).content as Array<{ type: string; text: string }>;
+        const meta = JSON.parse(content[0].text) as Record<string, unknown>;
+        assert.ok('source' in meta);
+        assert.ok('totalSamples' in meta);
+        assert.strictEqual(meta.mode, 'wall');
+    });
+
+    // --- No-data guard ------------------------------------------------------
+
+    test('tools return a helpful message when no profiling data is available', async () => {
+        const stats = new AustinStats(); // empty — overallTotal === 0
+        server = startedServer(stats);
+        const res = await post(server.port, {
+            jsonrpc: '2.0', method: 'tools/call', id: 11,
+            params: { name: 'get_top', arguments: {} },
+        }) as Record<string, unknown>;
+
+        const content = (res.result as Record<string, unknown>).content as Array<{ type: string; text: string }>;
+        assert.ok(content[0].text.includes('No profiling data'));
+    });
+
+    test('unknown tool name returns a helpful message', async () => {
+        const stats = await makeStats('P1;T1;/a.py:fn:1 100\n');
+        server = startedServer(stats);
+        const res = await post(server.port, {
+            jsonrpc: '2.0', method: 'tools/call', id: 12,
+            params: { name: 'does_not_exist', arguments: {} },
+        }) as Record<string, unknown>;
+
+        const content = (res.result as Record<string, unknown>).content as Array<{ type: string; text: string }>;
+        assert.ok(content[0].text.includes('Unknown tool'));
+    });
+});


### PR DESCRIPTION
Exposes profiling data (top functions, call stacks, metadata) to AI chat sessions via a lightweight MCP HTTP server built on Node.js built-ins. The server starts lazily on first data and is configurable via austin.mcpPort.