### PR TITLE
fix: attach permissions handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ instructions for your platform. If you want to compile from sources or use one
 of the available release binaries, you can specify the absolute location of the
 Austin binary in the settings.
 
+> [!WARNING]
+> On macOS and Linux, this extension may prompt you for your administrator
+> password when starting or stopping a profiling session. This is because
+> Austin requires elevated privileges to profile processes. You can avoid
+> password prompts by adding Austin to your sudoers file (see below).
+
 
 ## Usage
 
@@ -31,11 +37,11 @@ task, or a one-off execution.
 > the binary, e.g. `/home/user/project/.venv/bin/austin`.
 
 > [!NOTE]
-> MacOS users should consider adding a rule for Austin to their
-> `sudoers` file. This will allow you to run `sudo austin ...` without having to
-> type your user password. This is required if you want to run Austin through
-> the extension tasks. To add a rule for Austin to the `sudoers` file, run `sudo
-> visudo` and add
+> macOS and Linux users should add Austin to their `sudoers` file to avoid
+> password prompts when starting the profiler. However, stopping the profiler
+> (detaching from a process) may still require your password unless you also add
+> `kill` to the sudoers. To add Austin to the `sudoers` file, run `sudo visudo`
+> and add
 > ~~~
 > <USER>        ALL = (root) NOPASSWD: <PATH_TO_AUSTIN>
 > ~~~
@@ -45,6 +51,12 @@ task, or a one-off execution.
 > ~~~
 > <USER>        ALL = (root) NOPASSWD:SETENV: <PATH_TO_AUSTIN>
 > ~~~
+>
+> If you prefer not to add Austin to sudoers, you can install an askpass helper:
+> - **macOS**: The extension includes a built-in askpass that will prompt for your
+>   password via a dialog.
+> - **Linux**: Install `ssh-askpass`, `ksshaskpass`, or `ksshaskpass-gnome`, or
+>   use `zenity` (`sudo apt install zenity` on Debian/Ubuntu).
 
 ### Profiling with tasks
 

--- a/package.json
+++ b/package.json
@@ -230,7 +230,8 @@
   },
   "scripts": {
     "vscode:prepublish": "npm run esbuild-base -- --minify",
-    "compile": "tsc -p ./",
+    "compile": "tsc -p ./ && npm run copy-askpass",
+    "copy-askpass": "node -e \"const fs=require('fs');const p=require('path');const src='src/askpass',dst='out/askpass';if(fs.existsSync(src)){if(!fs.existsSync(dst))fs.mkdirSync(dst,{recursive:true});fs.readdirSync(src).forEach(f=>{const srcPath=p.join(src,f),dstPath=p.join(dst,f);fs.copyFileSync(srcPath,dstPath);fs.chmodSync(dstPath,0o755)})}\"",
     "watch": "tsc -watch -p ./",
     "pretest": "npm run compile && npm run lint",
     "lint": "eslint src",

--- a/src/askpass/linux-askpass.sh
+++ b/src/askpass/linux-askpass.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Simple askpass for Linux desktops. Uses zenity or kdialog.
+
+if command -v zenity >/dev/null 2>&1; then
+  zenity --password --title="Authentication required"
+  exit $?
+fi
+
+if command -v kdialog >/dev/null 2>&1; then
+  kdialog --password "Authentication required"
+  exit $?
+fi
+
+# No GUI password helper available
+printf 'Austin askpass: no GUI password helper found (install zenity or kdialog).\n' >&2
+exit 1

--- a/src/askpass/macos-askpass.sh
+++ b/src/askpass/macos-askpass.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Minimal askpass helper for macOS using AppleScript.
+# Prints the entered password to stdout for SUDO_ASKPASS.
+osascript -e 'tell application "System Events" to display dialog "Administrator privileges are required. Enter your password:" default answer "" with hidden answer with title "Austin"' -e 'text returned of result'

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -100,11 +100,6 @@ export class AustinController {
         this._currentExecution = await vscode.tasks.executeTask(task);
     }
 
-    public detach() {
-        this._currentExecution?.terminate();
-        this._currentExecution = undefined;
-    }
-
     public clearCurrentExecution(execution: vscode.TaskExecution) {
         if (this._currentExecution === execution) {
             this._currentExecution = undefined;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,6 +8,7 @@ import { CallStackViewProvider } from './providers/callstack';
 import { AustinProfileTaskProvider } from './providers/task';
 import { AustinRuntimeSettings } from './settings';
 import { AustinMode } from './types';
+import { onAustinTerminated, getCurrentExecutor } from './providers/executor';
 import { AUSTIN_MIN_MAJOR, AustinVersionError, checkAustinVersion } from './utils/versionCheck';
 import { AustinMcpServer } from './providers/mcp';
 import { updateMcpJsonIfPresent, writeMcpJson } from './utils/mcpJson';
@@ -145,9 +146,17 @@ export async function activate(context: vscode.ExtensionContext) {
 	detachStatusBarItem.tooltip = "Stop Austin";
 	detachStatusBarItem.backgroundColor = new vscode.ThemeColor("statusBarItem.warningBackground");
 
+	// Note: We don't use controller.detach() which would call task.terminate().
+	// Instead, we call requestDetach() directly on the executor to attempt killing
+	// the austin process. The task only ends when the process actually exits
+	// (via onAustinTerminated event). This allows the user to retry detaching
+	// if the first attempt fails (e.g., wrong password in askpass).
 	context.subscriptions.push(
 		vscode.commands.registerCommand('austin-vscode.detach', () => {
-			controller.detach();
+			const executor = getCurrentExecutor();
+			if (executor) {
+				executor.requestDetach();
+			}
 		})
 	);
 
@@ -191,15 +200,20 @@ export async function activate(context: vscode.ExtensionContext) {
 		vscode.tasks.onDidEndTask((e) => {
 			if (e.execution.task.definition.type === "austin") {
 				controller.clearCurrentExecution(e.execution);
-				detachStatusBarItem.hide();
-				pauseStatusBarItem.hide();
-				stats.paused = false;
-				pauseStatusBarItem.text = "$(debug-pause) Pause";
-				pauseStatusBarItem.tooltip = "Pause UI refreshes (data collection continues)";
-				flameGraphViewProvider.showOpenButton();
-				topProvider.hideLive();
-				callStackProvider.hideLive();
 			}
+		})
+	);
+
+	context.subscriptions.push(
+		onAustinTerminated.event(() => {
+			detachStatusBarItem.hide();
+			pauseStatusBarItem.hide();
+			stats.paused = false;
+			pauseStatusBarItem.text = "$(debug-pause) Pause";
+			pauseStatusBarItem.tooltip = "Pause UI refreshes (data collection continues)";
+			flameGraphViewProvider.showOpenButton();
+			topProvider.hideLive();
+			callStackProvider.hideLive();
 		})
 	);
 

--- a/src/providers/executor.ts
+++ b/src/providers/executor.ts
@@ -1,23 +1,69 @@
 import * as vscode from "vscode";
+import * as fs from "fs";
+import * as path from "path";
+
+import { ChildProcess, spawn, spawnSync } from "child_process";
 
 import { AustinCommandArguments } from "../utils/commandFactory";
-
-import { ChildProcess, spawn } from "child_process";
 import { AustinStats } from "../model";
 import { StreamingMojoParser } from "../utils/mojo";
 import { clearDecorations, setLinesHeat } from "../view";
 
 import { DotenvPopulateInput, config } from "dotenv";
 
+export const onAustinTerminated = new vscode.EventEmitter<boolean>();
+let currentExecutor: AustinCommandExecutor | undefined;
+
+export function setCurrentExecutor(executor: AustinCommandExecutor | undefined) {
+  currentExecutor = executor;
+}
+
+export function getCurrentExecutor(): AustinCommandExecutor | undefined {
+  return currentExecutor;
+}
+
 
 function maybeEnquote(arg: string): string {
   return arg.indexOf(' ') >= 0 ? `"${arg}"` : arg;
 }
 
+/**
+ * Finite-state machine for AustinCommandExecutor lifecycle management.
+ *
+ * States:
+ * - Running: austin is actively profiling
+ * - Stopping: kill has been requested but process hasn't exited yet
+ * - Terminated: process has exited
+ *
+ * State Transitions:
+ *
+ * Running -> Stopping:
+ *   - Triggered by: user clicking "Detach Austin" or terminal closing
+ *   - Action: attempt to kill the austin process (via requestDetach() or close())
+ *
+ * Stopping -> Terminated:
+ *   - Triggered by: austin process exiting after kill was requested
+ *   - Action: onAustinTerminated event fires, status bar hides
+ *
+ * Stopping -> Running:
+ *   - Triggered by: sudo kill fails (wrong password, user cancels, etc.)
+ *   - Action: state reset via onFailure callback, user can retry
+ *
+ * Running -> Terminated:
+ *   - Triggered by: austin process exiting unexpectedly (success, error, or crash)
+ *   - Action: appropriate message shown, task ends
+ */
+
+enum ExecutorState {
+  Running = "running",
+  Stopping = "stopping",
+  Terminated = "terminated"
+}
+
 export class AustinCommandExecutor implements vscode.Pseudoterminal {
   private austinProcess: ChildProcess | undefined;
-  private _killed: boolean = false;
-  private _processExited: boolean = false;
+  private state: ExecutorState = ExecutorState.Running;
+  private _hasAskpass: boolean = false;
   result: number = 0;
 
   constructor(
@@ -36,7 +82,7 @@ export class AustinCommandExecutor implements vscode.Pseudoterminal {
 
   open(initialDimensions: vscode.TerminalDimensions | undefined): void {
     this.writeEmitter.fire(`Starting Profiler in ${this.cwd}.\r\n`);
-    const resolvedArgs = this.command.args;
+    let resolvedArgs = this.command.args;
 
     let env: DotenvPopulateInput = {};
     for (let key in process.env) {
@@ -49,9 +95,21 @@ export class AustinCommandExecutor implements vscode.Pseudoterminal {
       config({ path: this.command.envFile, processEnv: env });
     }
 
+    const childEnv: DotenvPopulateInput = {};
+    for (let k in env) { childEnv[k] = env[k]; }
+
+    if (this.command.cmd === 'sudo') {
+      const askpass = findAskpass();
+      if (askpass) {
+        this._hasAskpass = true;
+        childEnv["SUDO_ASKPASS"] = askpass;
+        resolvedArgs = ['-A', ...resolvedArgs];
+      }
+    }
+
     this.austinProcess = spawn(this.command.cmd, resolvedArgs, {
-      "cwd": this.cwd,
-      "env": env,
+      cwd: this.cwd,
+      env: childEnv,
     }); // NOSONAR
     const args = resolvedArgs.map(maybeEnquote).join(' ');
     this.writeEmitter.fire(`Running '${maybeEnquote(this.command.cmd)}' with args '${args}'.\r\n`);
@@ -61,10 +119,12 @@ export class AustinCommandExecutor implements vscode.Pseudoterminal {
     const fileName = this.fileName;
 
     if (this.austinProcess) {
+      // Triggered when the austin child process crashes or fails to start
       this.austinProcess.on("error", (err) => {
         this.writeEmitter.fire(err.message);
       });
 
+      // Triggered when austin writes to stderr (e.g., error messages)
       this.austinProcess.stderr!.on("data", (data) => {
         this.output.append(data.toString());
       });
@@ -73,6 +133,7 @@ export class AustinCommandExecutor implements vscode.Pseudoterminal {
       this.stats.begin(fileName);
       const parser = new StreamingMojoParser(this.stats);
 
+      // Triggered when austin writes profiling data to stdout
       this.austinProcess.stdout!.on("data", (chunk: Buffer) => {
         parser.push(chunk);
       });
@@ -88,10 +149,13 @@ export class AustinCommandExecutor implements vscode.Pseudoterminal {
         }
       }, 1000);
 
+      // Triggered when the austin process exits (for any reason)
       this.austinProcess.on("close", (code) => {
-        this._processExited = true;
+        const wasStopping = this.state === ExecutorState.Stopping;
+        this.state = ExecutorState.Terminated;
         clearInterval(refreshInterval);
-        if (this._killed) {
+        onAustinTerminated.fire(true);
+        if (wasStopping) {
           // Intentional stop: we sent a kill signal before the process exited
           this.closeEmitter.fire(0);
           const label = fileName ?? "process";
@@ -108,7 +172,16 @@ export class AustinCommandExecutor implements vscode.Pseudoterminal {
           this.writeEmitter.fire(`austin process exited with code ${code}\r\n`);
           this.result = code!;
           this.closeEmitter.fire(code!);
-          vscode.window.showErrorMessage(`Austin exited with code ${code}. Check the Austin output channel for details.`);
+          if (this.command.cmd === 'sudo' && !this._hasAskpass) {
+            const instructions = process.platform === 'darwin'
+              ? 'Run the following in Terminal to add Austin to sudoers without a password:\necho "username ALL=(ALL) NOPASSWD: /path/to/austin" | sudo tee /etc/sudoers.d/austin'
+              : process.platform === 'linux'
+                ? 'Install an askpass helper (e.g., ssh-askpass or zenity) or add Austin to sudoers without a password.'
+                : 'Add Austin to sudoers without a password.';
+            vscode.window.showErrorMessage(`Failed to start Austin. ${instructions}`);
+          } else {
+            vscode.window.showErrorMessage(`Austin exited with code ${code}. Check the Austin output channel for details.`);
+          }
           parser.finalize();
           this.stats.notifyError();
         } else {
@@ -131,13 +204,132 @@ export class AustinCommandExecutor implements vscode.Pseudoterminal {
     }
   }
 
-  close(): void {
-    // The terminal has been closed. Shutdown the build.
-    if (this.austinProcess && !this.austinProcess.killed) {
-      if (!this._processExited) {
-        this._killed = true;
-      }
-      this.austinProcess.kill();
+  // Called when user clicks the "Detach Austin" status bar item
+  public requestDetach(): void {
+    // Request detachment - try to kill but don't end the task
+    if (this.state !== ExecutorState.Running || !this.austinProcess || this.austinProcess.killed) {
+      return;
     }
+    this.state = ExecutorState.Stopping;
+    const pid = this.austinProcess.pid;
+
+    if (this.command.cmd === 'sudo' && pid) {
+      // For sudo, the attemptSudoKill runs asynchronously.
+      // If it fails, onAustinTerminated won't fire, so we stay in Stopping.
+      // Allow user to retry - if they do, we'll try again.
+      attemptSudoKill(pid, this.cwd, () => {
+        // Callback when sudo fails - reset state to allow retry
+        this.state = ExecutorState.Running;
+      });
+    } else {
+      try {
+        this.austinProcess.kill();
+      } catch (err: any) {
+        if (err && (err.code === 'EPERM' || err.code === 'EACCES')) {
+          if (pid) {
+            attemptSudoKill(pid, this.cwd, () => {
+              this.state = ExecutorState.Running;
+            });
+          }
+        }
+      }
+    }
+  }
+
+  // Called when the terminal is closed (pseudoterminal is disposed)
+  close(): void {
+    // Terminal closed - same as requestDetach for sudo case
+    if (this.state !== ExecutorState.Running || !this.austinProcess || this.austinProcess.killed) {
+      return;
+    }
+    this.state = ExecutorState.Stopping;
+    const pid = this.austinProcess.pid;
+
+    if (this.command.cmd === 'sudo' && pid) {
+      attemptSudoKill(pid, this.cwd);
+      return;
+    }
+
+    try {
+      this.austinProcess.kill();
+    } catch (err: any) {
+      if (err && (err.code === 'EPERM' || err.code === 'EACCES')) {
+        if (pid) {
+          attemptSudoKill(pid, this.cwd);
+          return;
+        }
+      }
+      this.writeEmitter.fire(err?.message ?? String(err));
+    }
+    // Let the "close" event on the process fire closeEmitter, same as requestDetach().
+  }
+}
+
+/** @internal exported for testing */
+export function findAskpass(): string | undefined {
+  // Respect existing environment in case the user set a custom askpass
+  if (process.env.SUDO_ASKPASS) { return process.env.SUDO_ASKPASS; }
+
+  const platform = process.platform;
+  if (platform === 'darwin') {
+    const p = path.join(__dirname, '..', 'askpass', 'macos-askpass.sh');
+    if (fs.existsSync(p)) { return p; }
+  }
+
+  if (platform === 'linux') {
+    const candidates = ['ssh-askpass', 'ksshaskpass', 'ssh-askpass-gnome'];
+    for (const cmd of candidates) {
+      try {
+        const which = spawnSync('which', [cmd]);
+        if (which.status === 0) {
+          const resolved = which.stdout.toString().trim();
+          if (resolved) { return resolved; }
+        }
+      } catch {
+        // ignore
+      }
+    }
+    // Fallback: bundled askpass for linux if present
+    const p = path.join(__dirname, '..', 'askpass', 'linux-askpass.sh');
+    if (fs.existsSync(p)) { return p; }
+  }
+
+  return undefined;
+}
+
+function attemptSudoKill(pid: number, cwd: string, onFailure?: () => void) {
+  const askpass = findAskpass();
+  const env: NodeJS.ProcessEnv = {};
+  for (const k of Object.keys(process.env)) { env[k] = process.env[k]; }
+
+  if (askpass) {
+    env['SUDO_ASKPASS'] = askpass;
+    const sudoArgs = ['-A', 'kill', '-TERM', String(pid)];
+    const child = spawn('sudo', sudoArgs, { env, cwd, stdio: 'ignore' });
+    child.on('close', (code) => {
+      if (code !== 0) {
+        vscode.window.showWarningMessage(
+          'Failed to stop Austin (authentication failed or was cancelled). Click "Stop Austin" to try again.'
+        );
+        if (onFailure) { onFailure(); }
+      }
+    });
+    child.on('error', () => {
+      vscode.window.showWarningMessage(
+        'Failed to stop Austin (sudo not available). Add Austin to sudoers or install a sudo password helper.'
+      );
+      if (onFailure) { onFailure(); }
+    });
+  } else {
+    // No askpass available - open a minimal terminal for the user to authenticate manually.
+    vscode.window.showWarningMessage('Elevated privileges required to stop Austin. Check the terminal.');
+    const shellEnv: NodeJS.ProcessEnv = {};
+    for (const key of ['PATH', 'HOME', 'USER', 'SHELL', 'TERM', 'LANG', 'LC_ALL']) {
+      if (process.env[key] !== undefined) { shellEnv[key] = process.env[key]; }
+    }
+    const terminal = vscode.window.createTerminal({ cwd, env: shellEnv });
+    terminal.show();
+    terminal.sendText(`sudo kill -TERM ${pid}`);
+    if (onFailure) { onFailure(); }
   }
 }

--- a/src/providers/executor.ts
+++ b/src/providers/executor.ts
@@ -63,7 +63,9 @@ enum ExecutorState {
 export class AustinCommandExecutor implements vscode.Pseudoterminal {
   private austinProcess: ChildProcess | undefined;
   private state: ExecutorState = ExecutorState.Running;
-  private _hasAskpass: boolean = false;
+  // Set to true after the first attempt fails with a "no tty/no askpass" sudo
+  // error, so that the retry in open() knows to use our bundled askpass.
+  private _triedAskpass: boolean = false;
   result: number = 0;
 
   constructor(
@@ -98,14 +100,17 @@ export class AustinCommandExecutor implements vscode.Pseudoterminal {
     const childEnv: DotenvPopulateInput = {};
     for (let k in env) { childEnv[k] = env[k]; }
 
-    if (this.command.cmd === 'sudo') {
+    if (this.command.cmd === 'sudo' && this._triedAskpass) {
+      // Retry: vanilla sudo failed because no system auth mechanism was available.
+      // Fall back to our bundled askpass.
       const askpass = findAskpass();
       if (askpass) {
-        this._hasAskpass = true;
         childEnv["SUDO_ASKPASS"] = askpass;
         resolvedArgs = ['-A', ...resolvedArgs];
       }
     }
+    // On first attempt: no -A, no SUDO_ASKPASS — let the system handle auth
+    // (e.g., PrivilegesCLI, sudoers-configured askpass, cached credentials).
 
     this.austinProcess = spawn(this.command.cmd, resolvedArgs, {
       cwd: this.cwd,
@@ -125,8 +130,11 @@ export class AustinCommandExecutor implements vscode.Pseudoterminal {
       });
 
       // Triggered when austin writes to stderr (e.g., error messages)
+      let stderrData = '';
       this.austinProcess.stderr!.on("data", (data) => {
-        this.output.append(data.toString());
+        const s = data.toString();
+        stderrData += s;
+        this.output.append(s);
       });
 
       clearDecorations();
@@ -154,6 +162,17 @@ export class AustinCommandExecutor implements vscode.Pseudoterminal {
         const wasStopping = this.state === ExecutorState.Stopping;
         this.state = ExecutorState.Terminated;
         clearInterval(refreshInterval);
+
+        // If vanilla sudo failed because no password mechanism was available,
+        // retry once with our bundled askpass before reporting an error.
+        if (!wasStopping && code !== 0 && !this._triedAskpass &&
+            this.command.cmd === 'sudo' && sudoNeedsAskpass(stderrData)) {
+          this._triedAskpass = true;
+          this.state = ExecutorState.Running;
+          this.open(undefined);
+          return;
+        }
+
         onAustinTerminated.fire(true);
         if (wasStopping) {
           // Intentional stop: we sent a kill signal before the process exited
@@ -172,16 +191,7 @@ export class AustinCommandExecutor implements vscode.Pseudoterminal {
           this.writeEmitter.fire(`austin process exited with code ${code}\r\n`);
           this.result = code!;
           this.closeEmitter.fire(code!);
-          if (this.command.cmd === 'sudo' && !this._hasAskpass) {
-            const instructions = process.platform === 'darwin'
-              ? 'Run the following in Terminal to add Austin to sudoers without a password:\necho "username ALL=(ALL) NOPASSWD: /path/to/austin" | sudo tee /etc/sudoers.d/austin'
-              : process.platform === 'linux'
-                ? 'Install an askpass helper (e.g., ssh-askpass or zenity) or add Austin to sudoers without a password.'
-                : 'Add Austin to sudoers without a password.';
-            vscode.window.showErrorMessage(`Failed to start Austin. ${instructions}`);
-          } else {
-            vscode.window.showErrorMessage(`Austin exited with code ${code}. Check the Austin output channel for details.`);
-          }
+          vscode.window.showErrorMessage(`Austin exited with code ${code}. Check the Austin output channel for details.`);
           parser.finalize();
           this.stats.notifyError();
         } else {
@@ -297,39 +307,78 @@ export function findAskpass(): string | undefined {
   return undefined;
 }
 
+/** Returns true when sudo stderr indicates it had no way to prompt for a password. */
+function sudoNeedsAskpass(stderr: string): boolean {
+  return stderr.includes('no tty present') ||
+    stderr.includes('no askpass program') ||
+    stderr.includes('a terminal is required') ||
+    stderr.includes('must be run from a terminal');
+}
+
 function attemptSudoKill(pid: number, cwd: string, onFailure?: () => void) {
-  const askpass = findAskpass();
   const env: NodeJS.ProcessEnv = {};
   for (const k of Object.keys(process.env)) { env[k] = process.env[k]; }
 
-  if (askpass) {
-    env['SUDO_ASKPASS'] = askpass;
-    const sudoArgs = ['-A', 'kill', '-TERM', String(pid)];
-    const child = spawn('sudo', sudoArgs, { env, cwd, stdio: 'ignore' });
-    child.on('close', (code) => {
-      if (code !== 0) {
-        vscode.window.showWarningMessage(
-          'Failed to stop Austin (authentication failed or was cancelled). Click "Stop Austin" to try again.'
-        );
-        if (onFailure) { onFailure(); }
+  // First try vanilla sudo — respects cached credentials and any system-level
+  // auth mechanism (e.g., PrivilegesCLI, sudoers-configured password helper).
+  let stderrData = '';
+  const child = spawn('sudo', ['kill', '-TERM', String(pid)], {
+    env, cwd, stdio: ['ignore', 'ignore', 'pipe'],
+  });
+  child.stderr!.on('data', (d: Buffer) => { stderrData += d.toString(); });
+
+  child.on('close', (code) => {
+    if (code === 0) { return; }
+
+    if (sudoNeedsAskpass(stderrData)) {
+      // No system auth mechanism; retry with our bundled password helper.
+      const askpass = findAskpass();
+      if (askpass) {
+        const retryEnv = { ...env };
+        retryEnv['SUDO_ASKPASS'] = askpass;
+        const retry = spawn('sudo', ['-A', 'kill', '-TERM', String(pid)], {
+          env: retryEnv, cwd, stdio: 'ignore',
+        });
+        retry.on('close', (retryCode) => {
+          if (retryCode !== 0) {
+            vscode.window.showWarningMessage(
+              'Failed to stop Austin (authentication failed or was cancelled). Click "Stop Austin" to try again.'
+            );
+            if (onFailure) { onFailure(); }
+          }
+        });
+        retry.on('error', () => {
+          vscode.window.showWarningMessage(
+            'Failed to stop Austin (sudo not available). Add Austin to the sudoers file.'
+          );
+          if (onFailure) { onFailure(); }
+        });
+        return;
       }
-    });
-    child.on('error', () => {
+
+      // No password helper available — open a minimal terminal for manual auth.
+      vscode.window.showWarningMessage('Elevated privileges required to stop Austin. Check the terminal.');
+      const shellEnv: NodeJS.ProcessEnv = {};
+      for (const key of ['PATH', 'HOME', 'USER', 'SHELL', 'TERM', 'LANG', 'LC_ALL']) {
+        if (process.env[key] !== undefined) { shellEnv[key] = process.env[key]; }
+      }
+      const terminal = vscode.window.createTerminal({ cwd, env: shellEnv });
+      terminal.show();
+      terminal.sendText(`sudo kill -TERM ${pid}`);
+      if (onFailure) { onFailure(); }
+    } else {
+      // Vanilla sudo ran but authentication failed or was cancelled.
       vscode.window.showWarningMessage(
-        'Failed to stop Austin (sudo not available). Add Austin to sudoers or install a sudo password helper.'
+        'Failed to stop Austin (authentication failed or was cancelled). Click "Stop Austin" to try again.'
       );
       if (onFailure) { onFailure(); }
-    });
-  } else {
-    // No askpass available - open a minimal terminal for the user to authenticate manually.
-    vscode.window.showWarningMessage('Elevated privileges required to stop Austin. Check the terminal.');
-    const shellEnv: NodeJS.ProcessEnv = {};
-    for (const key of ['PATH', 'HOME', 'USER', 'SHELL', 'TERM', 'LANG', 'LC_ALL']) {
-      if (process.env[key] !== undefined) { shellEnv[key] = process.env[key]; }
     }
-    const terminal = vscode.window.createTerminal({ cwd, env: shellEnv });
-    terminal.show();
-    terminal.sendText(`sudo kill -TERM ${pid}`);
+  });
+
+  child.on('error', () => {
+    vscode.window.showWarningMessage(
+      'Failed to stop Austin (sudo not available). Add Austin to the sudoers file.'
+    );
     if (onFailure) { onFailure(); }
-  }
+  });
 }

--- a/src/providers/task.ts
+++ b/src/providers/task.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import { getAustinCommand } from "../utils/commandFactory";
-import { AustinCommandExecutor } from "./executor";
+import { AustinCommandExecutor, setCurrentExecutor } from "./executor";
 import { AustinStats } from "../model";
 import { isPythonExtensionAvailable } from "../utils/pythonExtension";
 import { AustinMode } from "../types";
@@ -17,6 +17,14 @@ export class AustinProfileTaskProvider implements vscode.TaskProvider {
     private output: vscode.OutputChannel,
   ) { }
 
+  private getSudoCommand(isAttach: boolean): string[] | undefined {
+    // Use sudo for attaching on both macOS and Linux, and for profiling on macOS
+    if (isAttach || platform() === "darwin") {
+      return ["sudo"];
+    }
+    return undefined;
+  }
+
   public provideTasks(): Thenable<vscode.Task[]> | undefined {
     if (!this.austinPromise) {
       // TODO: get automatic tasks, like "profile current file"
@@ -29,7 +37,7 @@ export class AustinProfileTaskProvider implements vscode.TaskProvider {
       {
         file: path.fsPath,
         type: "austin",
-        command: platform() === "darwin" ? ["sudo"] : undefined,
+        command: this.getSudoCommand(false),
         mode: AustinRuntimeSettings.getMode(),
       },
       vscode.TaskScope.Workspace,
@@ -41,7 +49,7 @@ export class AustinProfileTaskProvider implements vscode.TaskProvider {
       {
         pid,
         type: "austin",
-        command: platform() === "darwin" ? ["sudo"] : undefined,
+        command: this.getSudoCommand(true),
         mode: AustinRuntimeSettings.getMode(),
       },
       vscode.TaskScope.Workspace,
@@ -109,7 +117,7 @@ export class AustinProfileTaskProvider implements vscode.TaskProvider {
           ? `PID ${definition.pid}`
           : resolvedPath?.fsPath;
 
-        return new AustinCommandExecutor(
+        const executor = new AustinCommandExecutor(
           command,
           cwd!,
           this.output,
@@ -117,6 +125,8 @@ export class AustinProfileTaskProvider implements vscode.TaskProvider {
           fileName,
           definition.pid !== undefined,
         );
+        setCurrentExecutor(executor);
+        return executor;
       })
     );
   }

--- a/src/test/suite/executor.test.ts
+++ b/src/test/suite/executor.test.ts
@@ -1,0 +1,68 @@
+import * as assert from 'assert';
+import { findAskpass } from '../../providers/executor';
+
+// Side-effect imports required by model internals
+import '../../stringExtension';
+import '../../mapExtension';
+
+// ---------------------------------------------------------------------------
+// findAskpass
+// ---------------------------------------------------------------------------
+
+suite('findAskpass', () => {
+
+    // Save and restore SUDO_ASKPASS around each test so tests are isolated.
+    let savedAskpass: string | undefined;
+
+    setup(() => {
+        savedAskpass = process.env.SUDO_ASKPASS;
+        delete process.env.SUDO_ASKPASS;
+    });
+
+    teardown(() => {
+        if (savedAskpass === undefined) {
+            delete process.env.SUDO_ASKPASS;
+        } else {
+            process.env.SUDO_ASKPASS = savedAskpass;
+        }
+    });
+
+    test('returns SUDO_ASKPASS env var when set, regardless of platform', () => {
+        process.env.SUDO_ASKPASS = '/usr/lib/openssh/gnome-ssh-askpass';
+        assert.strictEqual(findAskpass(), '/usr/lib/openssh/gnome-ssh-askpass');
+    });
+
+    test('SUDO_ASKPASS takes precedence over any bundled or discovered helper', () => {
+        process.env.SUDO_ASKPASS = '/custom/my-askpass.sh';
+        const result = findAskpass();
+        assert.strictEqual(result, '/custom/my-askpass.sh');
+    });
+
+    test('returns a string or undefined (never throws)', () => {
+        // SUDO_ASKPASS unset - result depends on platform and installed tools,
+        // but the function must not throw.
+        assert.doesNotThrow(() => findAskpass());
+        const result = findAskpass();
+        assert.ok(result === undefined || typeof result === 'string');
+    });
+
+    test('on darwin, returns a string path when bundled script exists', function () {
+        if (process.platform !== 'darwin') { this.skip(); }
+        // The compiled extension's bundled script lives at out/askpass/macos-askpass.sh
+        // relative to out/providers/executor.js (__dirname).  Only assert that the
+        // returned path (when present) is a non-empty string.
+        const result = findAskpass();
+        if (result !== undefined) {
+            assert.ok(result.length > 0);
+            assert.ok(result.endsWith('.sh') || result.endsWith('askpass'));
+        }
+    });
+
+    test('returned path, when defined, does not contain shell-injectable characters', () => {
+        process.env.SUDO_ASKPASS = '/usr/bin/ssh-askpass';
+        const result = findAskpass()!;
+        // PATHs are passed via env var, not shell-interpolated, but sanity-check.
+        assert.ok(!result.includes('\n'), 'path must not contain newlines');
+        assert.ok(!result.includes('\0'), 'path must not contain null bytes');
+    });
+});

--- a/src/test/vscode-mock.ts
+++ b/src/test/vscode-mock.ts
@@ -19,6 +19,16 @@ nodeModule._resolveFilename = function (request: string, ...rest: unknown[]) {
     return origResolve.call(this, request, ...rest);
 };
 
+class EventEmitter<T> {
+    private listeners: Array<(e: T) => unknown> = [];
+    event = (listener: (e: T) => unknown) => {
+        this.listeners.push(listener);
+        return { dispose: () => { this.listeners = this.listeners.filter(l => l !== listener); } };
+    };
+    fire(data: T) { this.listeners.forEach(l => l(data)); }
+    dispose() { this.listeners = []; }
+}
+
 const mock = {
     workspace: {
         workspaceFolders: undefined as undefined,
@@ -26,14 +36,17 @@ const mock = {
             get: (_key: string, defaultValue: unknown) => defaultValue,
             update: () => undefined,
         }),
+        asRelativePath: (p: string) => p,
     },
     window: {
         showErrorMessage: () => undefined,
+        showWarningMessage: () => undefined,
         showInformationMessage: () => undefined,
         showInputBox: () => Promise.resolve(undefined),
         showQuickPick: () => Promise.resolve(undefined),
         get activeTextEditor() { return undefined; },
         createTextEditorDecorationType: () => ({ dispose: () => undefined }),
+        createTerminal: () => ({ show: () => undefined, sendText: () => undefined }),
     },
     commands: {
         executeCommand: () => Promise.resolve(undefined),
@@ -43,6 +56,7 @@ const mock = {
             fsPath: [base.fsPath, ...parts].join('/'),
         }),
     },
+    EventEmitter,
     Range: class Range {
         constructor(public start: unknown, public end: unknown) {}
     },


### PR DESCRIPTION
We improve the handling of permissions when trying to attach/detach. In particular, we make sure that we can handle the case where the Austin binary is in the sudoers file, but the kill signal still requires elevated privileges to succeed.