### PR TITLE
feat: register MCP server via VS Code native API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Change Log
 
+## [1.1.0]
+
+- Added AI chat integration via MCP: profiling data is exposed to AI agents
+  (e.g. GitHub Copilot, Claude Code, Cursor) through three tools — `get_top`,
+  `get_call_stacks`, and `get_metadata`. The server starts automatically when
+  the extension activates and binds to an OS-assigned port, so multiple VS Code
+  windows can run simultaneously without conflicts.
+
+- Added the **Austin: Generate .mcp.json** command, which writes a `.mcp.json`
+  file to the workspace root for agents with their own MCP client. If the file
+  already has an austin entry, the port is updated automatically on every
+  restart.
+
 ## [1.0.0]
 
 ### Flame Graph
@@ -36,15 +49,6 @@
   call path; a "Sync with flame graph" toggle controls this behavior.
 
 - Both panels show a sortable **Own** and **Total** column.
-
-### AI Chat Integration
-
-- Added an MCP server that exposes profiling data to AI chat sessions (e.g.
-  Claude Code). The server starts lazily when the first profiling data becomes
-  available and listens on port 7891 by default (configurable via
-  `austin.mcpPort`; set to `0` to disable). Three tools are provided:
-  `get_top`, `get_call_stacks`, and `get_metadata`. See the README for setup
-  instructions.
 
 ### Other Improvements
 

--- a/README.md
+++ b/README.md
@@ -157,41 +157,33 @@ available to collect.
 
 ## AI Chat Integration (MCP)
 
-The extension exposes profiling data to AI chat sessions via an
-[MCP](https://modelcontextprotocol.io/) server. The server starts lazily the
-first time profiling data becomes available, and stops when the extension
-deactivates.
+The extension exposes profiling data to AI chat sessions via an MCP server that
+starts automatically when the extension activates. The following tools are
+available once a profiling session has data:
 
-The server listens on port **7891** by default (configurable via
-`austin.mcpPort`; set to `0` to disable).
+| Tool | Parameters | Description |
+|---|---|---|
+| `get_top` | `limit` (optional) | Top functions sorted by own time. |
+| `get_call_stacks` | `depth` (optional, default 5) | Process→thread→function call-stack tree. |
+| `get_metadata` | — | Source file, sampling mode, interval, and total sample count. |
 
-For example, to connect Claude Code to the server, add a `.mcp.json` file to
-your project root:
+All time and memory values are expressed as a percentage of the total observed
+metric for the session.
 
-```json
-{
-    "mcpServers": {
-        "austin": {
-            "type": "http",
-            "url": "http://localhost:7891/mcp"
-        }
-    }
-}
-```
+### GitHub Copilot
 
-> [!NOTE]
-> Adjust the port in the URL if you have changed `austin.mcpPort`.
+The MCP server is registered automatically with VS Code's built-in MCP client.
+No configuration is required — the tools appear in Copilot agent mode as soon
+as the extension activates, under the names `mcp_austin_get_top`,
+`mcp_austin_get_call_stacks`, and `mcp_austin_get_metadata`.
 
-Once connected, the following tools are available in your chat session:
+### Other agents (Claude Code, Cursor, etc.)
 
-| Tool | Description |
-|---|---|
-| `get_top` | Top functions by own time. Accepts an optional `limit`. |
-| `get_call_stacks` | Process→thread→function call-stack tree. Accepts an optional `depth` (default: 5). |
-| `get_metadata` | Profiling session metadata: source file, mode, interval, sample count. |
-
-Percentage values are relative to the total observed metric (CPU time, wall
-time, or memory, depending on the profiling mode).
+Run the **Austin: Generate .mcp.json** command from the Command Palette to
+write a `.mcp.json` file to your workspace root. This file points the agent's
+MCP client at the local server. You only need to do this once: if a `.mcp.json`
+with an austin entry already exists, the extension updates the port
+automatically on every restart.
 
 
 ## Configuration

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@types/glob": "^7.1.3",
         "@types/mocha": "^8.0.4",
         "@types/node": "^12.11.7",
-        "@types/vscode": "^1.57.0",
+        "@types/vscode": "^1.101.0",
         "@typescript-eslint/eslint-plugin": "^8.57.2",
         "@typescript-eslint/parser": "^8.57.2",
         "@vscode/test-electron": "^2.3.8",
@@ -28,7 +28,7 @@
         "typescript": "^4.1.2"
       },
       "engines": {
-        "vscode": "^1.57.0"
+        "vscode": "^1.101.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -822,10 +822,11 @@
       "dev": true
     },
     "node_modules/@types/vscode": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.67.0.tgz",
-      "integrity": "sha512-GH8BDf8cw9AC9080uneJfulhSa7KHSMI2s/CyKePXoGNos9J486w2V4YKoeNUqIEkW4hKoEAWp6/cXTwyGj47g==",
-      "dev": true
+      "version": "1.101.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.101.0.tgz",
+      "integrity": "sha512-ZWf0IWa+NGegdW3iU42AcDTFHWW7fApLdkdnBqwYEtHVIBGbTu0ZNQKP/kX3Ds/uMJXIMQNAojHR4vexCEEz5Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.57.2",
@@ -3671,9 +3672,9 @@
       "dev": true
     },
     "@types/vscode": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.67.0.tgz",
-      "integrity": "sha512-GH8BDf8cw9AC9080uneJfulhSa7KHSMI2s/CyKePXoGNos9J486w2V4YKoeNUqIEkW4hKoEAWp6/cXTwyGj47g==",
+      "version": "1.101.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.101.0.tgz",
+      "integrity": "sha512-ZWf0IWa+NGegdW3iU42AcDTFHWW7fApLdkdnBqwYEtHVIBGbTu0ZNQKP/kX3Ds/uMJXIMQNAojHR4vexCEEz5Q==",
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
@@ -3730,8 +3731,7 @@
       "version": "8.57.2",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.57.2.tgz",
       "integrity": "sha512-3Lm5DSM+DCowsUOJC+YqHHnKEfFh5CoGkj5Z31NQSNF4l5wdOwqGn99wmwN/LImhfY3KJnmordBq/4+VDe2eKw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@typescript-eslint/type-utils": {
       "version": "8.57.2",
@@ -3853,8 +3853,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "agent-base": {
       "version": "7.1.1",
@@ -4304,8 +4303,7 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "file-entry-cache": {
       "version": "8.0.0",
@@ -5132,8 +5130,7 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
       "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Austin extension for VS Code",
   "version": "0.0.0",
   "engines": {
-    "vscode": "^1.57.0"
+    "vscode": "^1.101.0"
   },
   "repository": {
     "type": "github",
@@ -28,12 +28,7 @@
     "ps-list": "^7.2.0"
   },
   "activationEvents": [
-    "onCommand:austin-vscode.profile",
-    "onCommand:austin-vscode.attach",
-    "onCommand:austin-vscode.load",
-    "onStartupFinished",
-    "onView:austin-vscode.flame-graph",
-    "onView:austin-vscode.austin-stats"
+    "onStartupFinished"
   ],
   "main": "./out/extension.js",
   "contributes": {
@@ -82,14 +77,15 @@
             "Both percent and absolute metric values"
           ],
           "default": "Percent"
-        },
-        "austin.mcpPort": {
-          "description": "Port for the Austin MCP server, which exposes profiling data to AI chat sessions (e.g. Claude Code). The server starts lazily when the first profiling data becomes available. Set to 0 to disable.",
-          "type": "number",
-          "default": 7891
         }
       }
     },
+    "mcpServerDefinitionProviders": [
+      {
+        "id": "austin",
+        "label": "Austin"
+      }
+    ],
     "viewsContainers": {
       "panel": [
         {
@@ -154,6 +150,11 @@
       {
         "command": "austin-vscode.toggleChildren",
         "title": "Toggle Austin Children Profiling"
+      },
+      {
+        "command": "austin-vscode.generateMcpJson",
+        "title": "Generate .mcp.json",
+        "category": "Austin"
       }
     ],
     "keybindings": [
@@ -244,7 +245,7 @@
     "@types/glob": "^7.1.3",
     "@types/mocha": "^8.0.4",
     "@types/node": "^12.11.7",
-    "@types/vscode": "^1.57.0",
+    "@types/vscode": "^1.101.0",
     "@typescript-eslint/eslint-plugin": "^8.57.2",
     "@typescript-eslint/parser": "^8.57.2",
     "@vscode/test-electron": "^2.3.8",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,21 +10,33 @@ import { AustinRuntimeSettings } from './settings';
 import { AustinMode } from './types';
 import { AUSTIN_MIN_MAJOR, AustinVersionError, checkAustinVersion } from './utils/versionCheck';
 import { AustinMcpServer } from './providers/mcp';
+import { updateMcpJsonIfPresent, writeMcpJson } from './utils/mcpJson';
 
 
-export function activate(context: vscode.ExtensionContext) {
+export async function activate(context: vscode.ExtensionContext) {
 	vscode.workspace.onDidChangeTextDocument((_changeEvent) => {
 		clearDecorations();
 	});
 
 	const stats = new AustinStats();
 
-	const mcpPort = AustinRuntimeSettings.getMcpPort();
-	if (mcpPort > 0) {
-		const mcpServer = new AustinMcpServer(mcpPort);
-		stats.registerAfterCallback((s) => mcpServer.update(s));
-		context.subscriptions.push({ dispose: () => mcpServer.dispose() });
-	}
+	const mcpServer = new AustinMcpServer();
+	await mcpServer.start();
+	stats.registerAfterCallback((s) => mcpServer.update(s));
+	const mcpNeverChange = new vscode.EventEmitter<void>();
+	context.subscriptions.push(
+		mcpNeverChange,
+		{ dispose: () => mcpServer.dispose() },
+		vscode.lm.registerMcpServerDefinitionProvider('austin', {
+			onDidChangeMcpServerDefinitions: mcpNeverChange.event,
+			provideMcpServerDefinitions() {
+				return [new vscode.McpHttpServerDefinition(
+					'Austin',
+					vscode.Uri.parse(`http://127.0.0.1:${mcpServer.port}/mcp`),
+				)];
+			},
+		})
+	);
 
 	context.subscriptions.push(
 		vscode.window.onDidChangeActiveTextEditor((editor) => {
@@ -36,7 +48,10 @@ export function activate(context: vscode.ExtensionContext) {
 		})
 	);
 
+	updateMcpJsonIfPresent(mcpServer.port);
+
 	const output = vscode.window.createOutputChannel("Austin");
+	output.appendLine(`Austin MCP server listening on http://127.0.0.1:${mcpServer.port}/mcp`);
 
 	const austinProfileProvider = new AustinProfileTaskProvider(stats, output);
 	const controller = new AustinController(stats, austinProfileProvider, output);
@@ -99,6 +114,22 @@ export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(
 		vscode.commands.registerCommand('austin-vscode.load', () => {
 			controller.openSampleFile();
+		})
+	);
+
+	context.subscriptions.push(
+		vscode.commands.registerCommand('austin-vscode.generateMcpJson', async () => {
+			const folders = vscode.workspace.workspaceFolders;
+			if (!folders || folders.length === 0) {
+				vscode.window.showErrorMessage('Austin: no workspace folder is open.');
+				return;
+			}
+			const folder = folders.length === 1
+				? folders[0]
+				: await vscode.window.showWorkspaceFolderPick({ placeHolder: 'Select workspace folder for .mcp.json' });
+			if (!folder) { return; }
+			writeMcpJson(folder, mcpServer.port);
+			vscode.window.showInformationMessage(`Austin: .mcp.json written to ${folder.uri.fsPath}`);
 		})
 	);
 

--- a/src/providers/mcp.ts
+++ b/src/providers/mcp.ts
@@ -1,5 +1,4 @@
 import * as http from 'http';
-import * as vscode from 'vscode';
 import { AustinStats, TopStats } from '../model';
 
 const MCP_PROTOCOL_VERSION = '2024-11-05';
@@ -79,20 +78,28 @@ export class AustinMcpServer {
     private _httpServer: http.Server | null = null;
     private _stats: AustinStats | null = null;
 
-    constructor(private readonly _port: number) { }
-
-    /**
-     * Called on every stats refresh. Starts the HTTP server lazily on the
-     * first call so that the server only runs when profiling data exists.
-     */
-    update(stats: AustinStats): void {
-        this._stats = stats;
-        if (!this._httpServer) {
-            this._startServer();
-        }
+    /** Starts the server on an OS-assigned port. Resolves once the port is known. */
+    start(): Promise<void> {
+        return new Promise((resolve, reject) => {
+            const server = http.createServer((req, res) => this._handleRequest(req, res));
+            server.on('error', reject);
+            server.listen(0, '127.0.0.1', () => {
+                server.removeListener('error', reject);
+                server.on('error', (err: NodeJS.ErrnoException) => {
+                    console.error(`Austin MCP server error: ${err.message}`);
+                });
+                resolve();
+            });
+            this._httpServer = server;
+        });
     }
 
-    /** Returns the port the server is actually listening on (0 until started). */
+    /** Updates the stats served by this server. Called on every profiling refresh. */
+    update(stats: AustinStats): void {
+        this._stats = stats;
+    }
+
+    /** Returns the port the server is listening on. */
     get port(): number {
         const addr = this._httpServer?.address();
         if (addr && typeof addr === 'object') { return addr.port; }
@@ -103,29 +110,6 @@ export class AustinMcpServer {
         this._httpServer?.close();
         this._httpServer = null;
         this._stats = null;
-    }
-
-    // -----------------------------------------------------------------------
-    // Private
-    // -----------------------------------------------------------------------
-
-    private _startServer(): void {
-        const server = http.createServer((req, res) => this._handleRequest(req, res));
-
-        server.on('error', (err: NodeJS.ErrnoException) => {
-            if (err.code === 'EADDRINUSE') {
-                vscode.window.showWarningMessage(
-                    `Austin MCP server could not start: port ${this._port} is already in use. ` +
-                    `Change the austin.mcpPort setting to use a different port.`
-                );
-            } else {
-                vscode.window.showWarningMessage(`Austin MCP server error: ${err.message}`);
-            }
-            this._httpServer = null;
-        });
-
-        server.listen(this._port);
-        this._httpServer = server;
     }
 
     private _handleRequest(req: http.IncomingMessage, res: http.ServerResponse): void {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -5,7 +5,6 @@ export const DEFAULT_PATH = "austin";
 export const DEFAULT_INTERVAL = 100;
 export const DEFAULT_MODE = AustinMode.WallTime;
 export const DEFAULT_LINE_STATS = AustinLineStats.PERCENT;
-export const DEFAULT_MCP_PORT = 7891;
 
 export class AustinRuntimeSettings {
     private static config = vscode.workspace.getConfiguration('austin');
@@ -78,7 +77,4 @@ export class AustinRuntimeSettings {
         AustinRuntimeSettings.config.update("children", children, vscode.ConfigurationTarget.Global);
     }
 
-    public static getMcpPort(): number {
-        return AustinRuntimeSettings.config.get<number>("mcpPort", DEFAULT_MCP_PORT);
-    }
 }

--- a/src/test/suite/mcp.test.ts
+++ b/src/test/suite/mcp.test.ts
@@ -42,8 +42,9 @@ function makeStats(lines: string): Promise<AustinStats> {
     });
 }
 
-function startedServer(stats: AustinStats): AustinMcpServer {
-    const server = new AustinMcpServer(0); // port 0 = OS-assigned
+async function startedServer(stats: AustinStats): Promise<AustinMcpServer> {
+    const server = new AustinMcpServer();
+    await server.start();
     server.update(stats);
     return server;
 }
@@ -63,20 +64,20 @@ suite('AustinMcpServer', () => {
 
     // --- Lifecycle ----------------------------------------------------------
 
-    test('server does not start before update() is called', () => {
-        server = new AustinMcpServer(0);
+    test('port is 0 before start() is called', () => {
+        server = new AustinMcpServer();
         assert.strictEqual(server.port, 0);
     });
 
-    test('server starts lazily on first update() call', async () => {
-        const stats = await makeStats('P1;T1;/a.py:fn:1 100\n');
-        server = startedServer(stats);
-        assert.ok(server.port > 0, 'port should be assigned after update()');
+    test('start() assigns a non-zero port', async () => {
+        server = new AustinMcpServer();
+        await server.start();
+        assert.ok(server.port > 0, 'port should be assigned after start()');
     });
 
     test('dispose() stops the server', async () => {
         const stats = await makeStats('P1;T1;/a.py:fn:1 100\n');
-        server = startedServer(stats);
+        server = await startedServer(stats);
         const port = server.port;
         server.dispose();
         server = null;
@@ -92,7 +93,7 @@ suite('AustinMcpServer', () => {
 
     test('initialize returns server info and capabilities', async () => {
         const stats = await makeStats('P1;T1;/a.py:fn:1 100\n');
-        server = startedServer(stats);
+        server = await startedServer(stats);
         const res = await post(server.port, {
             jsonrpc: '2.0', method: 'initialize', id: 1,
             params: { protocolVersion: '2024-11-05', clientInfo: { name: 'test', version: '0' }, capabilities: {} },
@@ -107,21 +108,21 @@ suite('AustinMcpServer', () => {
 
     test('ping returns empty result', async () => {
         const stats = await makeStats('P1;T1;/a.py:fn:1 100\n');
-        server = startedServer(stats);
+        server = await startedServer(stats);
         const res = await post(server.port, { jsonrpc: '2.0', method: 'ping', id: 2 }) as Record<string, unknown>;
         assert.deepStrictEqual(res.result, {});
     });
 
     test('notifications/initialized returns 202 (no body)', async () => {
         const stats = await makeStats('P1;T1;/a.py:fn:1 100\n');
-        server = startedServer(stats);
+        server = await startedServer(stats);
         const res = await post(server.port, { jsonrpc: '2.0', method: 'notifications/initialized' });
         assert.strictEqual(res, null);
     });
 
     test('tools/list returns all three tools', async () => {
         const stats = await makeStats('P1;T1;/a.py:fn:1 100\n');
-        server = startedServer(stats);
+        server = await startedServer(stats);
         const res = await post(server.port, { jsonrpc: '2.0', method: 'tools/list', id: 3 }) as Record<string, unknown>;
         const tools = (res.result as Record<string, unknown>).tools as Array<{ name: string }>;
         const names = tools.map(t => t.name);
@@ -132,19 +133,21 @@ suite('AustinMcpServer', () => {
 
     test('unknown method returns error -32601', async () => {
         const stats = await makeStats('P1;T1;/a.py:fn:1 100\n');
-        server = startedServer(stats);
+        server = await startedServer(stats);
         const res = await post(server.port, { jsonrpc: '2.0', method: 'nonexistent', id: 4 }) as Record<string, unknown>;
         assert.strictEqual((res.error as Record<string, unknown>).code, -32601);
     });
 
-    test('malformed JSON returns 400', (done) => {
-        makeStats('P1;T1;/a.py:fn:1 100\n').then((stats) => {
-            server = startedServer(stats);
+    test('malformed JSON returns 400', async () => {
+        const stats = await makeStats('P1;T1;/a.py:fn:1 100\n');
+        server = await startedServer(stats);
+        await new Promise<void>((resolve, reject) => {
             const req = http.request(
                 { hostname: '127.0.0.1', port: server!.port, path: '/mcp', method: 'POST',
                   headers: { 'Content-Type': 'application/json' } },
-                (res) => { assert.strictEqual(res.statusCode, 400); done(); }
+                (res) => { assert.strictEqual(res.statusCode, 400); resolve(); }
             );
+            req.on('error', reject);
             req.end('{bad json');
         });
     });
@@ -156,7 +159,7 @@ suite('AustinMcpServer', () => {
             'P1;T1;/a.py:outer:1;/a.py:inner:2 100\n' +
             'P1;T1;/a.py:outer:1 50\n'
         );
-        server = startedServer(stats);
+        server = await startedServer(stats);
         const res = await post(server.port, {
             jsonrpc: '2.0', method: 'tools/call', id: 5,
             params: { name: 'get_top', arguments: {} },
@@ -174,7 +177,7 @@ suite('AustinMcpServer', () => {
             'P1;T1;/a.py:f2:2 80\n' +
             'P1;T1;/a.py:f3:3 60\n'
         );
-        server = startedServer(stats);
+        server = await startedServer(stats);
         const res = await post(server.port, {
             jsonrpc: '2.0', method: 'tools/call', id: 6,
             params: { name: 'get_top', arguments: { limit: 2 } },
@@ -187,7 +190,7 @@ suite('AustinMcpServer', () => {
 
     test('get_top includes ownPct, totalPct, scope, module, line fields', async () => {
         const stats = await makeStats('P1;T1;/a.py:fn:5 200\n');
-        server = startedServer(stats);
+        server = await startedServer(stats);
         const res = await post(server.port, {
             jsonrpc: '2.0', method: 'tools/call', id: 7,
             params: { name: 'get_top', arguments: {} },
@@ -207,7 +210,7 @@ suite('AustinMcpServer', () => {
 
     test('get_call_stacks returns process/thread/function tree', async () => {
         const stats = await makeStats('P1;T1;/a.py:fn:1 100\n');
-        server = startedServer(stats);
+        server = await startedServer(stats);
         const res = await post(server.port, {
             jsonrpc: '2.0', method: 'tools/call', id: 8,
             params: { name: 'get_call_stacks', arguments: {} },
@@ -222,7 +225,7 @@ suite('AustinMcpServer', () => {
 
     test('get_call_stacks respects depth=1', async () => {
         const stats = await makeStats('P1;T1;/a.py:outer:1;/a.py:inner:2 100\n');
-        server = startedServer(stats);
+        server = await startedServer(stats);
         const res = await post(server.port, {
             jsonrpc: '2.0', method: 'tools/call', id: 9,
             params: { name: 'get_call_stacks', arguments: { depth: 1 } },
@@ -239,7 +242,7 @@ suite('AustinMcpServer', () => {
 
     test('get_metadata returns source and totalSamples', async () => {
         const stats = await makeStats('# mode: wall\nP1;T1;/a.py:fn:1 100\n');
-        server = startedServer(stats);
+        server = await startedServer(stats);
         const res = await post(server.port, {
             jsonrpc: '2.0', method: 'tools/call', id: 10,
             params: { name: 'get_metadata', arguments: {} },
@@ -256,7 +259,7 @@ suite('AustinMcpServer', () => {
 
     test('tools return a helpful message when no profiling data is available', async () => {
         const stats = new AustinStats(); // empty — overallTotal === 0
-        server = startedServer(stats);
+        server = await startedServer(stats);
         const res = await post(server.port, {
             jsonrpc: '2.0', method: 'tools/call', id: 11,
             params: { name: 'get_top', arguments: {} },
@@ -268,7 +271,7 @@ suite('AustinMcpServer', () => {
 
     test('unknown tool name returns a helpful message', async () => {
         const stats = await makeStats('P1;T1;/a.py:fn:1 100\n');
-        server = startedServer(stats);
+        server = await startedServer(stats);
         const res = await post(server.port, {
             jsonrpc: '2.0', method: 'tools/call', id: 12,
             params: { name: 'does_not_exist', arguments: {} },

--- a/src/utils/mcpJson.ts
+++ b/src/utils/mcpJson.ts
@@ -1,0 +1,60 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+const AUSTIN_KEY = 'austin';
+const MCP_JSON = '.mcp.json';
+
+interface McpServerEntry {
+    type: string;
+    url: string;
+    [key: string]: unknown;
+}
+
+interface McpConfig {
+    mcpServers?: Record<string, McpServerEntry>;
+    [key: string]: unknown;
+}
+
+function austinEntry(port: number): McpServerEntry {
+    return { type: 'http', url: `http://127.0.0.1:${port}/mcp` };
+}
+
+function readConfig(filePath: string): McpConfig {
+    try {
+        return JSON.parse(fs.readFileSync(filePath, 'utf8')) as McpConfig;
+    } catch {
+        return {};
+    }
+}
+
+function writeConfig(filePath: string, config: McpConfig): void {
+    fs.writeFileSync(filePath, JSON.stringify(config, null, 4) + '\n');
+}
+
+/** Writes or updates the austin entry in `.mcp.json` for the given folder. */
+export function writeMcpJson(folder: vscode.WorkspaceFolder, port: number): void {
+    const filePath = path.join(folder.uri.fsPath, MCP_JSON);
+    const config = readConfig(filePath);
+    if (!config.mcpServers) { config.mcpServers = {}; }
+    config.mcpServers[AUSTIN_KEY] = austinEntry(port);
+    writeConfig(filePath, config);
+}
+
+/**
+ * Scans all workspace folders for an existing `.mcp.json` that already has an
+ * austin entry and updates the port in each one found.
+ */
+export function updateMcpJsonIfPresent(port: number): void {
+    for (const folder of vscode.workspace.workspaceFolders ?? []) {
+        const filePath = path.join(folder.uri.fsPath, MCP_JSON);
+        if (!fs.existsSync(filePath)) { continue; }
+        const config = readConfig(filePath);
+        if (!config.mcpServers?.[AUSTIN_KEY]) { continue; }
+        config.mcpServers[AUSTIN_KEY] = {
+            ...config.mcpServers[AUSTIN_KEY],
+            ...austinEntry(port),
+        };
+        writeConfig(filePath, config);
+    }
+}


### PR DESCRIPTION
Replaces the fixed-port HTTP server with vscode.lm.registerMcpServerDefinitionProvider, so each VS Code window gets its own OS-assigned port with no manual configuration and no cross-window port conflicts. Bumps engines.vscode and @types/vscode to ^1.101.0.