### PR TITLE
fix: include node_modules in package

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,7 +1,6 @@
 art/**
 .vscode/**
 .vscode-test/**
-node_modules/**
 out/test/**
 out/**/*.js.map
 src/**


### PR DESCRIPTION
We make sure that node_modules is include in the extension package. Previously it was excluded when the dependency on d3-flame-graph was removed.