### PR TITLE
feat: add GC activity visualisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Change Log
 
+## [1.2.0]
+
+### GC Activity
+
+- Added a **GC Activity** timeline panel inside the flame graph view, showing
+  per-thread garbage collector activity as proportional time spans. Hovering a
+  span shows the top-3 contributing leaf frames. Clicking a thread label zooms
+  the flame graph to that thread.
+
+- Added a **GC Top** sidebar panel listing the functions that were on the stack
+  during GC collection, with own and total GC time percentages, per-thread GC
+  summaries, and a filter bar. Clicking a thread row zooms the flame graph to
+  that thread; clicking a frame row opens the source file at that location.
+
+- Added a **GC** toggle in the status bar to enable or disable GC data
+  collection (`-g` / `--gc` flag). The toggle is persisted across sessions.
+
+- Added a `get_gc_data` MCP tool that exposes per-thread GC fractions and
+  the top functions executing during GC collection to AI chat agents.
+
 ## [1.1.2]
 
 - Fixed more packaging issues.

--- a/README.md
+++ b/README.md
@@ -155,9 +155,22 @@ string. To reset the view, simply press <kbd>R</kbd>. Conveniently, you can
 bring up the open dialog with <kbd>O</kbd> while the focus is on the flame graph
 panel.
 
-The extension also adds two interactive tree views in the side bar to explore
-the sampled call stack and the top functions. Click on the Austin logo in the
-activity bar to reveal them.
+The extension also adds interactive tree views in the side bar to explore the
+sampled call stack, the top functions, and GC activity. Click on the Austin logo
+in the activity bar to reveal them.
+
+### GC Activity
+
+Enable garbage collector data collection with the **GC** toggle in the status
+bar. When GC data is present, a collapsible **GC Activity** swimlane panel
+appears above the flame graph, showing per-thread GC spans as proportional
+blocks on a timeline. Hovering a span reveals the top contributing frames;
+clicking a thread label zooms the flame graph to that thread.
+
+The **GC Top** sidebar panel lists the functions that were on the stack during
+GC collection, ranked by own GC time, with a per-thread summary at the top.
+Clicking a thread row zooms the flame graph to that thread; clicking a frame
+row opens the source file at the corresponding line.
 
 
 ### Expression-level heat maps
@@ -178,6 +191,7 @@ available once a profiling session has data:
 | `get_top` | `limit` (optional) | Top functions sorted by own time. |
 | `get_call_stacks` | `depth` (optional, default 5) | Process→thread→function call-stack tree. |
 | `get_metadata` | — | Source file, sampling mode, interval, and total sample count. |
+| `get_gc_data` | `limit` (optional) | Per-thread GC time fractions and top functions on the stack during GC, ranked by own GC time. Returns `available: false` if GC collection was not enabled for the session. |
 
 All time and memory values are expressed as a percentage of the total observed
 metric for the session.
@@ -187,7 +201,8 @@ metric for the session.
 The MCP server is registered automatically with VS Code's built-in MCP client.
 No configuration is required — the tools appear in Copilot agent mode as soon
 as the extension activates, under the names `mcp_austin_get_top`,
-`mcp_austin_get_call_stacks`, and `mcp_austin_get_metadata`.
+`mcp_austin_get_call_stacks`, `mcp_austin_get_metadata`, and
+`mcp_austin_get_gc_data`.
 
 ### Other agents (Claude Code, Cursor, etc.)
 

--- a/media/austin.css
+++ b/media/austin.css
@@ -86,9 +86,9 @@ body {
 }
 
 .welcome-key kbd {
-    background: var(--vscode-keybindingLabel-background, rgba(128,128,128,0.2));
-    border: 1px solid var(--vscode-keybindingLabel-border, rgba(128,128,128,0.4));
-    border-bottom: 2px solid var(--vscode-keybindingLabel-bottomBorder, rgba(128,128,128,0.6));
+    background: var(--vscode-keybindingLabel-background, rgba(128, 128, 128, 0.2));
+    border: 1px solid var(--vscode-keybindingLabel-border, rgba(128, 128, 128, 0.4));
+    border-bottom: 2px solid var(--vscode-keybindingLabel-bottomBorder, rgba(128, 128, 128, 0.6));
     border-radius: 3px;
     padding: 1px 4px;
     color: var(--vscode-keybindingLabel-foreground, var(--vscode-foreground));
@@ -134,6 +134,7 @@ button {
     background-color: rgba(45, 59, 70, 0.8);
     padding: 4px;
     position: fixed;
+    z-index: 10;
     width: 100%;
     height: 24px;
     box-shadow: 0px 0px 16px 0px #000000;
@@ -144,8 +145,8 @@ button {
 
 #search-box {
     margin-left: auto;
-    background: rgba(0,0,0,0.25);
-    border: 1px solid rgba(255,255,255,0.2);
+    background: rgba(0, 0, 0, 0.25);
+    border: 1px solid rgba(255, 255, 255, 0.2);
     border-radius: 4px;
     color: antiquewhite;
     font-size: 11px;
@@ -155,10 +156,17 @@ button {
     outline: none;
 }
 
-#search-box::placeholder { color: rgba(255,235,205,0.4); }
-#search-box:focus { border-color: rgba(255,255,255,0.5); background: rgba(0,0,0,0.4); }
+#search-box::placeholder {
+    color: rgba(255, 235, 205, 0.4);
+}
 
-#header-open, #header-share {
+#search-box:focus {
+    border-color: rgba(255, 255, 255, 0.5);
+    background: rgba(0, 0, 0, 0.4);
+}
+
+#header-open,
+#header-share {
     margin-left: 4px;
     flex-shrink: 0;
     background: none !important;
@@ -175,14 +183,22 @@ button {
     opacity: 0.75;
 }
 
-#header-open:hover, #header-share:hover {
+#header-open:hover,
+#header-share:hover {
     opacity: 1;
     background: rgba(255, 255, 255, 0.1) !important;
 }
 
 @keyframes austin-live-pulse {
-    0%, 100% { opacity: 1; }
-    50%       { opacity: 0.35; }
+
+    0%,
+    100% {
+        opacity: 1;
+    }
+
+    50% {
+        opacity: 0.35;
+    }
 }
 
 #austin-logo.live {
@@ -192,6 +208,102 @@ button {
 #chart {
     padding-top: 32px;
     padding-bottom: 36px;
+}
+
+#gc-panel {
+    width: 100%;
+    backdrop-filter: blur(12px);
+    background-color: rgba(40, 50, 58, 0.92);
+    display: none;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+}
+
+#gc-details>summary {
+    cursor: pointer;
+    padding: 3px 10px;
+    font-size: 10px;
+    font-weight: 600;
+    color: antiquewhite;
+    opacity: 0.75;
+    user-select: none;
+    list-style: none;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+#gc-details>summary::before {
+    content: '▶';
+    font-size: 8px;
+    transition: transform 0.15s;
+}
+
+#gc-details[open]>summary::before {
+    transform: rotate(90deg);
+}
+
+#gc-swimlanes {
+    padding: 4px 10px 6px 10px;
+}
+
+.swimlane-row {
+    display: flex;
+    align-items: center;
+    height: 18px;
+    margin-bottom: 3px;
+}
+
+.swimlane-row.active {
+    background: rgba(255, 255, 255, 0.06);
+    border-radius: 3px;
+}
+
+.swimlane-row.active .swimlane-label {
+    opacity: 1;
+}
+
+.swimlane-label {
+    font-size: 10px;
+    color: antiquewhite;
+    opacity: 0.65;
+    width: 130px;
+    flex-shrink: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    padding-right: 8px;
+}
+
+.swimlane-track {
+    flex: 1;
+    position: relative;
+    height: 14px;
+    border-radius: 2px;
+    overflow: hidden;
+    background: rgba(255, 255, 255, 0.04);
+}
+
+.swimlane-block {
+    position: absolute;
+    height: 100%;
+    border-radius: 1px;
+    background: rgba(220, 80, 30, 0.75);
+    cursor: default;
+}
+
+#gc-tooltip {
+    position: fixed;
+    background: rgba(24, 28, 32, 0.97);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 5px;
+    padding: 7px 11px;
+    font-size: 11px;
+    color: antiquewhite;
+    pointer-events: none;
+    z-index: 100;
+    display: none;
+    max-width: 280px;
+    line-height: 1.5;
 }
 
 #footer {

--- a/media/flamegraph.js
+++ b/media/flamegraph.js
@@ -5,7 +5,7 @@
 
     // ── Utilities (loaded from flamegraph-utils.js) ───────────────────────────
     // @ts-ignore
-    const { colorFor, basename, isEmpty, footerText } = FlamegraphUtils;
+    const { colorFor, basename, isEmpty, footerText, esc } = FlamegraphUtils;
 
     /** @param {any} node @param {string} parentKey */
     function addPathKeys(node, parentKey) {
@@ -437,6 +437,137 @@
         if (modeSpan) { modeSpan.innerHTML = mode; }
     }
 
+    /** Returns the [r,g,b] triple for the current profile mode. */
+    function modeRgb() {
+        switch (currentMode) {
+            case 'wall':   return [192, 192, 64];
+            case 'memory': return [64,  192, 64];
+            default:       return [192, 64,  64];  // cpu
+        }
+    }
+
+    // ── GC Swimlanes ──────────────────────────────────────────────────────────
+
+    const gcPanel   = document.getElementById('gc-panel');
+    const gcDetails = /** @type {HTMLDetailsElement|null} */ (document.getElementById('gc-details'));
+    const gcLanes   = document.getElementById('gc-swimlanes');
+
+    const gcTooltip = (() => {
+        const el = document.createElement('div');
+        el.id = 'gc-tooltip';
+        document.body.appendChild(el);
+        return el;
+    })();
+
+    /** @param {MouseEvent} e */
+    function positionGCTooltip(e) {
+        const margin = 14;
+        const tw = gcTooltip.offsetWidth;
+        const th = gcTooltip.offsetHeight;
+        let x = e.clientX + margin;
+        let y = e.clientY + margin;
+        if (x + tw > window.innerWidth)  { x = e.clientX - tw - margin; }
+        if (y + th > window.innerHeight) { y = e.clientY - th - margin; }
+        gcTooltip.style.left = x + 'px';
+        gcTooltip.style.top  = y + 'px';
+    }
+
+    /**
+     * Walk the hierarchy to find a thread node by pid:tid key.
+     * @param {string} threadKey  "${pid}:${iid}:${tid}"
+     * @returns {any|null}
+     */
+    function findThreadNode(threadKey) {
+        if (!rootNode) { return null; }
+        const colonIdx = threadKey.indexOf(':');
+        if (colonIdx < 0) { return null; }
+        const pid = threadKey.slice(0, colonIdx);
+        const tid = threadKey.slice(colonIdx + 1);
+        for (const proc of (rootNode.children || [])) {
+            if (proc.name === `Process ${pid}`) {
+                for (const thread of (proc.children || [])) {
+                    if (thread.name === `Thread ${tid}`) { return thread; }
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Render pre-computed GC spans (built by the extension backend).
+     * @param {any[]} threadSpans
+     */
+    function loadGCSpans(threadSpans) {
+        if (!gcLanes || !gcPanel) { return; }
+        gcLanes.innerHTML = '';
+
+        if (!threadSpans || threadSpans.length === 0) {
+            gcPanel.style.display = 'none';
+            return;
+        }
+
+        const [mr, mg, mb] = modeRgb();
+        const spanColor      = `rgba(${mr},${mg},${mb},0.75)`;
+        const highlightColor = `rgba(${mr},${mg},${mb},0.15)`;
+
+        for (const { label, threadKey, spans } of threadSpans) {
+            const row = document.createElement('div');
+            row.className = 'swimlane-row';
+
+            const labelEl = document.createElement('span');
+            labelEl.className = 'swimlane-label';
+            labelEl.textContent = label;
+            labelEl.title = 'Click to focus thread in flame graph';
+            labelEl.style.cursor = 'pointer';
+            labelEl.addEventListener('click', () => {
+                // Deactivate all rows, activate this one
+                gcLanes.querySelectorAll('.swimlane-row').forEach(r => {
+                    r.classList.remove('active');
+                    /** @type {HTMLElement} */ (r).style.background = '';
+                });
+                row.classList.add('active');
+                row.style.background = highlightColor;
+                const node = findThreadNode(threadKey);
+                if (node) { zoomTo(node); }
+            });
+            row.appendChild(labelEl);
+
+            const track = document.createElement('div');
+            track.className = 'swimlane-track';
+
+            for (const span of spans) {
+                const block = document.createElement('div');
+                block.className = 'swimlane-block';
+                block.style.left       = (span.startFraction * 100).toFixed(3) + '%';
+                block.style.width      = `max(2px, ${(span.durationFraction * 100).toFixed(3)}%)`;
+                block.style.background = spanColor;
+
+                block.addEventListener('mouseenter', (e) => {
+                    let html = `<div style="font-weight:600;margin-bottom:3px">${esc(label)}</div>`;
+                    html += `<div>GC span: <b>${span.durationPct}%</b> of thread time</div>`;
+                    if (span.topFrames.length > 0) {
+                        html += `<div style="margin-top:5px;opacity:0.65;font-size:10px;text-transform:uppercase;letter-spacing:0.05em">Top contributors</div>`;
+                        for (const { scope, module: mod, fraction } of span.topFrames) {
+                            html += `<div style="opacity:0.85;font-size:10px">· ${esc(scope)} <span style="opacity:0.6">(${(fraction * 100).toFixed(0)}%)</span></div>`;
+                        }
+                    }
+                    gcTooltip.innerHTML = html;
+                    gcTooltip.style.display = 'block';
+                    positionGCTooltip(/** @type {MouseEvent} */ (e));
+                });
+                block.addEventListener('mousemove', (e) => positionGCTooltip(/** @type {MouseEvent} */ (e)));
+                block.addEventListener('mouseleave', () => { gcTooltip.style.display = 'none'; });
+
+                track.appendChild(block);
+            }
+
+            row.appendChild(track);
+            gcLanes.appendChild(row);
+        }
+
+        gcPanel.style.display = gcLanes.children.length > 0 ? 'block' : 'none';
+    }
+
     // ── Messages ──────────────────────────────────────────────────────────────
 
     window.addEventListener('message', event => {
@@ -444,6 +575,9 @@
         if (msg === 'reset') {
             resetZoom();
             clearSearch();
+        } else if (msg.focusThread) {
+            const node = findThreadNode(msg.focusThread);
+            if (node) { zoomTo(node); }
         } else if (msg.focus) {
             focusByPathKey(msg.focus);
         } else if (msg.search) {
@@ -451,6 +585,7 @@
         } else if (msg.meta !== undefined) {
             setMetadata(msg.meta);
             loadData(msg.hierarchy);
+            loadGCSpans(msg.gcSpans);
             vscode.setState(msg);
         } else if (msg.hierarchy) {
             loadData(msg.hierarchy);
@@ -475,6 +610,7 @@
     if (state) {
         setMetadata(state.meta);
         loadData(state.hierarchy);
+        loadGCSpans(state.gcSpans);
     }
 
     vscode.postMessage('initialized');

--- a/media/gctop.js
+++ b/media/gctop.js
@@ -1,0 +1,208 @@
+(function () {
+    const vscode = acquireVsCodeApi();
+
+    let topFrames = [];
+    let hasThreadData = false;
+    let sortCol = 'gcOwn';
+    let sortAsc = false;
+    let filterTerm = '';
+
+    const loading        = document.getElementById('loading');
+    const filterInput    = document.getElementById('filter-input');
+    const filterClear    = document.getElementById('filter-clear');
+    const liveDot        = document.getElementById('live-dot');
+    const emptyEl        = document.getElementById('empty');
+    const emptyMsgEl     = document.getElementById('empty-msg');
+    const emptyActionsEl = document.getElementById('empty-actions');
+    const contentEl      = document.getElementById('content');
+    const threadSummary  = document.getElementById('thread-summary');
+
+    function setEmptyState(msg, showActions, color) {
+        emptyMsgEl.textContent = msg;
+        emptyMsgEl.style.color = color || '';
+        emptyActionsEl.style.display = showActions ? '' : 'none';
+    }
+
+    window.addEventListener('message', event => {
+        const msg = event.data;
+        if (msg.loading) {
+            topFrames = [];
+            hasThreadData = false;
+            filterTerm = '';
+            filterInput.value = '';
+            filterClear.classList.remove('visible');
+            setEmptyState('No profiling data loaded.', true);
+            render();
+            loading.classList.add('active');
+        } else if (msg.noGC) {
+            loading.classList.remove('active');
+            topFrames = [];
+            hasThreadData = false;
+            setEmptyState('No GC data available in this profile. Enable GC collection with the GC toggle in the status bar.', false);
+            render();
+        } else if (msg.threads !== undefined) {
+            loading.classList.remove('active');
+            topFrames = msg.topFrames || [];
+            hasThreadData = true;
+            renderThreadSummary(msg.threads || []);
+            render();
+        } else if (msg.live !== undefined) {
+            liveDot.classList.toggle('active', !!msg.live);
+        } else if (msg.error) {
+            loading.classList.remove('active');
+            topFrames = [];
+            hasThreadData = false;
+            setEmptyState('Profiling failed. Check the Austin output channel for details.', false, 'var(--vscode-errorForeground, #f48771)');
+            render();
+        }
+    });
+
+    function renderThreadSummary(threads) {
+        threadSummary.innerHTML = '';
+        for (const t of threads) {
+            const pct = (t.gcFraction * 100).toFixed(1);
+            const row = document.createElement('div');
+            row.className = 'thread-row';
+            row.style.cursor = 'pointer';
+            row.title = 'Click to focus thread in flame graph';
+            const c = statColor(t.gcFraction);
+            row.innerHTML =
+                `<span class="thread-label">P${t.pid} T${t.tid}</span>` +
+                `<div class="thread-bar-bg"><div class="thread-bar-fill" style="width:${Math.min(100, t.gcFraction * 100).toFixed(1)}%${c ? `;background:${c}` : ''}"></div></div>` +
+                `<span class="thread-pct"${c ? ` style="color:${c}"` : ''}>${pct}%</span>`;
+            const threadKey = `${t.pid}:${t.tid}`;
+            row.addEventListener('click', () => vscode.postMessage({ focusThread: threadKey }));
+            threadSummary.appendChild(row);
+        }
+    }
+
+    function render() {
+        if (!hasThreadData) {
+            emptyEl.style.display = '';
+            contentEl.style.display = 'none';
+            return;
+        }
+
+        emptyEl.style.display = 'none';
+        contentEl.style.display = '';
+
+        if (topFrames.length === 0) {
+            document.getElementById('tbody').innerHTML = '';
+            return;
+        }
+
+        const sorted = [...topFrames].sort((a, b) => {
+            const av = a[sortCol];
+            const bv = b[sortCol];
+            if (typeof av === 'number') { return sortAsc ? av - bv : bv - av; }
+            return sortAsc ? String(av).localeCompare(String(bv)) : String(bv).localeCompare(String(av));
+        });
+
+        const term = filterTerm.toLowerCase();
+        const filtered = term
+            ? sorted.filter(item =>
+                (item.scope  && item.scope.toLowerCase().includes(term)) ||
+                (item.module && item.module.toLowerCase().includes(term)))
+            : sorted;
+
+        const tbody = document.getElementById('tbody');
+        tbody.innerHTML = '';
+
+        for (const item of filtered) {
+            const tr = document.createElement('tr');
+            tr.className = 'frame-row';
+            if (item.module) { tr.title = item.module; }
+            tr.innerHTML =
+                gcCell(item.gcOwn) +
+                gcCell(item.gcTotal) +
+                funcCell(item.scope, item.module);
+            tr.addEventListener('click', () => {
+                if (item.module) { vscode.postMessage({ module: item.module, line: item.line }); }
+            });
+            tbody.appendChild(tr);
+        }
+    }
+
+    function gcCell(value) {
+        const pct = (value * 100).toFixed(2);
+        const w = Math.min(100, value * 100).toFixed(1);
+        const c = statColor(value);
+        const fillStyle = c ? `width:${w}%;background:${c}` : `width:${w}%`;
+        return `<td class="num"><div class="bar-row">` +
+            `<div class="bar-bg"><div class="bar-fill" style="${fillStyle}"></div></div>` +
+            `<span class="pct"${c ? ` style="color:${c}"` : ''}>${pct}%</span>` +
+            `</div></td>`;
+    }
+
+    function funcCell(scope, module) {
+        const mod = module ? basename(module) : '';
+        return `<td class="func" style="padding-left:6px">` +
+            `<span class="scope-name">${esc(scope || '')}</span>` +
+            (mod ? `<span class="scope-module">${esc(mod)}</span>` : '') +
+            `</td>`;
+    }
+
+    function statColor(value) {
+        const pct = value * 100;
+        if (pct >= 75) { return '#e74c3c'; }
+        if (pct >= 50) { return '#e67e22'; }
+        if (pct >= 25) { return '#f1c40f'; }
+        return null;
+    }
+
+    function esc(str) {
+        return String(str)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;');
+    }
+
+    function basename(path) {
+        return path.replace(/\\/g, '/').split('/').pop() || path;
+    }
+
+    // Sortable headers
+    document.querySelectorAll('th[data-col]').forEach(th => {
+        th.addEventListener('click', () => {
+            const col = th.dataset.col;
+            if (sortCol === col) {
+                sortAsc = !sortAsc;
+            } else {
+                sortCol = col;
+                sortAsc = col === 'scope';
+            }
+            document.querySelectorAll('th[data-col]').forEach(t => t.classList.remove('asc', 'desc'));
+            th.classList.add(sortAsc ? 'asc' : 'desc');
+            render();
+        });
+    });
+
+    // Filter
+    filterInput.addEventListener('input', e => {
+        filterTerm = e.target.value.trim();
+        filterClear.classList.toggle('visible', filterTerm.length > 0);
+        render();
+    });
+
+    filterClear.addEventListener('click', () => {
+        filterInput.value = '';
+        filterTerm = '';
+        filterClear.classList.remove('visible');
+        filterInput.focus();
+        render();
+    });
+
+    document.getElementById('open-btn').addEventListener('click', () => vscode.postMessage('open'));
+    document.getElementById('attach-btn').addEventListener('click', () => vscode.postMessage('attach'));
+
+    // Keep thead positioned below sticky toolbar
+    const toolbar = document.querySelector('.toolbar');
+    const updateToolbarHeight = () => {
+        document.documentElement.style.setProperty('--toolbar-h', toolbar.offsetHeight + 'px');
+    };
+    updateToolbarHeight();
+    new ResizeObserver(updateToolbarHeight).observe(toolbar);
+
+    vscode.postMessage('initialized');
+})();

--- a/package.json
+++ b/package.json
@@ -63,6 +63,11 @@
           "type": "boolean",
           "default": false
         },
+        "austin.gc": {
+          "description": "Collect GC data (-g)",
+          "type": "boolean",
+          "default": false
+        },
         "austin.lineStats": {
           "description": "Line statistics",
           "type": "string",
@@ -123,6 +128,12 @@
           "id": "austin-vscode.top",
           "name": "Top",
           "contextualTitle": "Top"
+        },
+        {
+          "type": "webview",
+          "id": "austin-vscode.gctop",
+          "name": "GC",
+          "contextualTitle": "GC"
         }
       ]
     },
@@ -155,6 +166,10 @@
       {
         "command": "austin-vscode.toggleChildren",
         "title": "Toggle Austin Children Profiling"
+      },
+      {
+        "command": "austin-vscode.toggleGC",
+        "title": "Toggle Austin GC Data Collection"
       },
       {
         "command": "austin-vscode.generateMcpJson",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,6 +4,7 @@ import { FlameGraphViewProvider } from './providers/flamegraph';
 import { AustinController } from './controller';
 import { AustinStats } from './model';
 import { TopViewProvider } from './providers/top';
+import { GCTopViewProvider } from './providers/gctop';
 import { CallStackViewProvider } from './providers/callstack';
 import { AustinProfileTaskProvider } from './providers/task';
 import { AustinRuntimeSettings } from './settings';
@@ -60,16 +61,20 @@ export async function activate(context: vscode.ExtensionContext) {
 	const flameGraphViewProvider = new FlameGraphViewProvider(context.extensionUri);
 	const topProvider = new TopViewProvider(context.extensionUri);
 	const callStackProvider = new CallStackViewProvider(context.extensionUri);
+	const gcTopProvider = new GCTopViewProvider(context.extensionUri);
 
 	stats.registerBeforeCallback(() => flameGraphViewProvider.showLoading());
 	stats.registerBeforeCallback(() => topProvider.showLoading());
 	stats.registerBeforeCallback(() => callStackProvider.showLoading());
+	stats.registerBeforeCallback(() => gcTopProvider.showLoading());
 	stats.registerAfterCallback((stats) => flameGraphViewProvider.refresh(stats));
 	stats.registerAfterCallback((stats) => topProvider.refresh(stats));
 	stats.registerAfterCallback((stats) => callStackProvider.refresh(stats));
+	stats.registerAfterCallback((stats) => gcTopProvider.refresh(stats));
 	stats.registerErrorCallback(() => flameGraphViewProvider.showError());
 	stats.registerErrorCallback(() => topProvider.showError());
 	stats.registerErrorCallback(() => callStackProvider.showError());
+	stats.registerErrorCallback(() => gcTopProvider.showError());
 	stats.registerAfterCallback((stats) => {
 		const editor = vscode.window.activeTextEditor;
 		if (editor?.document.uri.scheme === "file") {
@@ -80,6 +85,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
 	flameGraphViewProvider.onFrameSelected((pathKey) => callStackProvider.focusPath(pathKey));
 	callStackProvider.onFrameSelected((pathKey) => flameGraphViewProvider.focusFrame(pathKey));
+	gcTopProvider.onThreadSelected((threadKey) => flameGraphViewProvider.focusThread(threadKey));
 
 	context.subscriptions.push(
 		vscode.window.registerWebviewViewProvider(
@@ -98,6 +104,10 @@ export async function activate(context: vscode.ExtensionContext) {
 
 	context.subscriptions.push(
 		vscode.window.registerWebviewViewProvider(CallStackViewProvider.viewType, callStackProvider)
+	);
+
+	context.subscriptions.push(
+		vscode.window.registerWebviewViewProvider(GCTopViewProvider.viewType, gcTopProvider)
 	);
 
 	context.subscriptions.push(
@@ -192,6 +202,7 @@ export async function activate(context: vscode.ExtensionContext) {
 				flameGraphViewProvider.showDetachButton(isAttach);
 				topProvider.showLive();
 				callStackProvider.showLive();
+				gcTopProvider.showLive();
 			}
 		})
 	);
@@ -214,6 +225,7 @@ export async function activate(context: vscode.ExtensionContext) {
 			flameGraphViewProvider.showOpenButton();
 			topProvider.hideLive();
 			callStackProvider.hideLive();
+			gcTopProvider.hideLive();
 		})
 	);
 
@@ -267,6 +279,30 @@ export async function activate(context: vscode.ExtensionContext) {
 	);
 
 	childrenStatusBarItem.show();
+
+	// ---- GC toggle ----
+	const gcStatusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100);
+	gcStatusBarItem.command = "austin-vscode.toggleGC";
+	gcStatusBarItem.tooltip = "Toggle GC data collection (-g)";
+
+	let gcEnabled = AustinRuntimeSettings.getGC();
+
+	function updateGCStatusBar() {
+		gcStatusBarItem.text = gcEnabled
+			? "$(trash) GC: ON"
+			: "$(trash) GC: OFF";
+	}
+	updateGCStatusBar();
+
+	context.subscriptions.push(
+		vscode.commands.registerCommand("austin-vscode.toggleGC", () => {
+			gcEnabled = !gcEnabled;
+			AustinRuntimeSettings.setGC(gcEnabled);
+			updateGCStatusBar();
+		})
+	);
+
+	gcStatusBarItem.show();
 
 	// ---- Mode selector ----
 	const austinModeStatusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100);

--- a/src/model.ts
+++ b/src/model.ts
@@ -60,6 +60,14 @@ export class TopStats {
     }
 }
 
+export interface GCEvent {
+    pid: number;
+    tid: string;
+    gc: boolean;
+    metric: number;
+    frameKeys: string[];  // `${module}:${scope}` for each frame in the sample
+}
+
 export interface AustinStats {
     hierarchy: FlameNode;
     locationMap: Map<string, Map<string, [FrameObject, number, number]>>;
@@ -68,6 +76,7 @@ export interface AustinStats {
     overallTotal: number;
     source: string | null;
     metadata: Map<string, string>;
+    gcEvents: GCEvent[];
 }
 
 export class AustinStats implements AustinStats {
@@ -94,6 +103,7 @@ export class AustinStats implements AustinStats {
         this._errorCbs = [];
         this.source = null;
         this.metadata = new Map();
+        this.gcEvents = [];
     }
 
     clear() {
@@ -109,6 +119,7 @@ export class AustinStats implements AustinStats {
         };
         this.callStack = new TopStats();
         this.metadata = new Map();
+        this.gcEvents = [];
     }
 
     private updateTop(frameList: FrameObject[], metric: number) {
@@ -276,10 +287,18 @@ export class AustinStats implements AustinStats {
         this.metadata.set(key, value);
     }
 
-    public update(pid: number, tid: string, frames: FrameObject[], metric: number) {
+    public update(pid: number, tid: string, frames: FrameObject[], metric: number, gc: boolean = false) {
         if (metric > 0) {
             this.overallTotal += metric;
         }
+
+        this.gcEvents.push({
+            pid,
+            tid,
+            gc,
+            metric,
+            frameKeys: frames.map(f => `${f.module}:${f.scope}`),
+        });
 
         this.updateLineMap(frames, metric);
         this.updateTop(frames, metric);
@@ -365,7 +384,9 @@ export class AustinStats implements AustinStats {
             let frames = pidTidFrames.split(";");
             let pid = frames.shift()!.substring(1);
             let tid = frames.shift()!.substring(1);
-            this.update(Number(pid), tid, frames.map(parseFrame), Number(metric));
+            const parsedFrames = frames.map(parseFrame);
+            const gc = parsedFrames.some(f => f.module === "" && f.scope === "GC");
+            this.update(Number(pid), tid, parsedFrames.filter(f => !(f.module === "" && f.scope === "GC")), Number(metric), gc);
         });
 
         readInterface.on("close", this.finalize.bind(this));

--- a/src/providers/flamegraph.ts
+++ b/src/providers/flamegraph.ts
@@ -2,6 +2,112 @@ import * as vscode from 'vscode';
 import { AustinStats } from '../model';
 import { generateInteractiveSVG } from '../flamegraph-svg';
 
+export interface GCTopFrame {
+    scope: string;
+    module: string;
+    fraction: number;  // metric / span duration
+}
+
+export interface GCSpan {
+    startFraction: number;    // startMetric / threadTotalMetric
+    durationFraction: number; // duration    / threadTotalMetric
+    durationPct: string;      // pre-formatted "X.Y"
+    topFrames: GCTopFrame[];
+}
+
+export interface GCThreadSpans {
+    label: string;     // "P{pid} T{tid}"
+    threadKey: string;
+    spans: GCSpan[];
+}
+
+export const GC_MIN_FRACTION = 0.001; // drop spans < 0.1% of thread timeline
+
+export function computeGCSpans(stats: AustinStats): GCThreadSpans[] {
+    // Group events by thread, preserving temporal order
+    const threadEvents = new Map<string, typeof stats.gcEvents>();
+    for (const ev of stats.gcEvents) {
+        const key = `${ev.pid}:${ev.tid}`;
+        if (!threadEvents.has(key)) { threadEvents.set(key, []); }
+        threadEvents.get(key)!.push(ev);
+    }
+
+    const result: GCThreadSpans[] = [];
+
+    for (const [threadKey, evs] of threadEvents) {
+        const rawSpans: { startMetric: number; duration: number; frameCount: Map<string, number> }[] = [];
+        let totalMetric = 0;
+        let spanActive = false;
+        let spanStart = 0;
+        let spanDuration = 0;
+        let frameCount = new Map<string, number>();
+
+        const closeSpan = () => {
+            rawSpans.push({ startMetric: spanStart, duration: spanDuration, frameCount });
+            spanActive = false;
+        };
+
+        for (const ev of evs) {
+            if (ev.metric <= 0) { continue; }
+            if (ev.gc) {
+                if (!spanActive) {
+                    spanActive = true;
+                    spanStart = totalMetric;
+                    spanDuration = 0;
+                    frameCount = new Map();
+                }
+                spanDuration += ev.metric;
+                // Only attribute to the leaf (innermost) frame so fractions are
+                // mutually exclusive and sum to ≤ 100% across top contributors.
+                const leaf = ev.frameKeys.length > 0 ? ev.frameKeys[ev.frameKeys.length - 1] : null;
+                if (leaf) {
+                    frameCount.set(leaf, (frameCount.get(leaf) ?? 0) + ev.metric);
+                }
+            } else {
+                if (spanActive) { closeSpan(); }
+            }
+            totalMetric += ev.metric;
+        }
+        if (spanActive) { closeSpan(); }
+
+        if (totalMetric === 0) { continue; }
+
+        const spans: GCSpan[] = rawSpans
+            .filter(s => s.duration / totalMetric >= GC_MIN_FRACTION)
+            .map(s => {
+                const topFrames: GCTopFrame[] = [...s.frameCount.entries()]
+                    .sort((a, b) => b[1] - a[1])
+                    .slice(0, 3)
+                    .map(([key, metric]) => {
+                        const topStats = stats.top.get(key);
+                        const lastColon = key.lastIndexOf(':');
+                        return {
+                            scope: topStats?.scope ?? (lastColon >= 0 ? key.slice(lastColon + 1) : key),
+                            module: topStats?.module ?? (lastColon >= 0 ? key.slice(0, lastColon) : ''),
+                            fraction: s.duration > 0 ? metric / s.duration : 0,
+                        };
+                    });
+                return {
+                    startFraction: s.startMetric / totalMetric,
+                    durationFraction: s.duration / totalMetric,
+                    durationPct: (s.duration / totalMetric * 100).toFixed(1),
+                    topFrames,
+                };
+            });
+
+        if (spans.length === 0) { continue; }
+
+        const parts = threadKey.split(':');
+        result.push({
+            label: `P${parts[0]} T${parts.slice(1).join(':')}`,
+            threadKey,
+            spans,
+        });
+    }
+
+    return result;
+}
+
 
 
 export class FlameGraphViewProvider implements vscode.WebviewViewProvider {
@@ -138,6 +244,10 @@ export class FlameGraphViewProvider implements vscode.WebviewViewProvider {
         this._view?.webview.postMessage({ focus: pathKey });
     }
 
+    public focusThread(threadKey: string) {
+        this._view?.webview.postMessage({ focusThread: threadKey });
+    }
+
     public showDetachButton(isAttach: boolean = true) {
         this._sessionActive = true;
         this._isAttach = isAttach;
@@ -165,6 +275,7 @@ export class FlameGraphViewProvider implements vscode.WebviewViewProvider {
                 this._view.webview.postMessage({
                     "meta": { "mode": stats.metadata.get("mode") },
                     "hierarchy": stats.hierarchy,
+                    "gcSpans": computeGCSpans(stats),
                 });
             }
         }
@@ -192,7 +303,14 @@ export class FlameGraphViewProvider implements vscode.WebviewViewProvider {
             </head>
             <body class="logo">
                 <div id="header"><img id="austin-logo" class="${liveClass}" src="${austinLogoUri}" /><span class="vc" id="mode"></span><input id="search-box" type="text" placeholder="Search…" /><button id="header-share" onclick="onShare()">SHARE</button><button id="header-open" onclick="${btnOnclick}">${btnText}</button></div>
-                <div id="chart"></div>
+                <div id="chart">
+                    <div id="gc-panel">
+                        <details id="gc-details">
+                            <summary id="gc-summary">GC Activity</summary>
+                            <div id="gc-swimlanes"></div>
+                        </details>
+                    </div>
+                </div>
                 <div id="footer"></div>
 
                 <script type="text/javascript" src="${flameGraphUtilsUri}"></script>

--- a/src/providers/gctop.ts
+++ b/src/providers/gctop.ts
@@ -1,0 +1,476 @@
+import * as vscode from 'vscode';
+import { AustinStats } from '../model';
+
+interface GCThreadSummary {
+    pid: number;
+    tid: string;
+    gcFraction: number;
+}
+
+interface GCFrameItem {
+    key: string;
+    scope: string;
+    module: string;
+    line: number;
+    gcOwn: number;   // fraction of overallTotal
+    gcTotal: number; // fraction of overallTotal
+}
+
+export class GCTopViewProvider implements vscode.WebviewViewProvider {
+
+    public static readonly viewType = 'austin-vscode.gctop';
+
+    private _view?: vscode.WebviewView;
+    private _stats: AustinStats | null = null;
+    private _initialized: boolean = false;
+    private _onThreadSelected?: (threadKey: string) => void;
+
+    constructor(
+        private readonly _extensionUri: vscode.Uri,
+    ) { }
+
+    public onThreadSelected(cb: (threadKey: string) => void) {
+        this._onThreadSelected = cb;
+    }
+
+    public resolveWebviewView(
+        webviewView: vscode.WebviewView,
+        _context: vscode.WebviewViewResolveContext,
+        _token: vscode.CancellationToken,
+    ) {
+        this._view = webviewView;
+        this._initialized = false;
+
+        webviewView.webview.options = {
+            enableScripts: true,
+            localResourceRoots: [this._extensionUri],
+        };
+
+        webviewView.webview.onDidReceiveMessage(data => {
+            if (data === 'initialized') {
+                this._initialized = true;
+                if (this._stats) {
+                    this._postData(this._stats);
+                }
+                return;
+            }
+            if (data === 'open') {
+                vscode.commands.executeCommand('austin-vscode.load');
+                return;
+            }
+            if (data === 'attach') {
+                vscode.commands.executeCommand('austin-vscode.attach');
+                return;
+            }
+            if (data.focusThread !== undefined) {
+                this._onThreadSelected?.(data.focusThread);
+                return;
+            }
+            if (data.module !== undefined) {
+                vscode.commands.executeCommand('austin-vscode.openSourceAtLine', data.module, data.line || 0);
+            }
+        });
+
+        webviewView.webview.html = this._getHtml(webviewView.webview, this._stats);
+    }
+
+    public showLoading() {
+        this._view?.webview.postMessage({ loading: true });
+    }
+
+    public showError() {
+        this._view?.webview.postMessage({ error: true });
+    }
+
+    public showLive() {
+        this._view?.webview.postMessage({ live: true });
+    }
+
+    public hideLive() {
+        this._view?.webview.postMessage({ live: false });
+    }
+
+    public refresh(stats: AustinStats) {
+        this._stats = stats;
+        if (this._view && this._initialized) {
+            this._postData(stats);
+        }
+    }
+
+    private _postData(stats: AustinStats) {
+        if (!stats.gcEvents.length) {
+            this._view!.webview.postMessage({ noGC: true });
+            return;
+        }
+
+        // Accumulate per-thread and per-frame GC metrics from the event log
+        const threadMap = new Map<string, { pid: number; tid: string; gcMetric: number; totalMetric: number }>();
+        const frameOwn = new Map<string, number>();
+        const frameAll = new Map<string, number>();
+
+        for (const ev of stats.gcEvents) {
+            if (ev.metric <= 0) { continue; }
+
+            const threadKey = `${ev.pid}:${ev.tid}`;
+            if (!threadMap.has(threadKey)) {
+                threadMap.set(threadKey, { pid: ev.pid, tid: ev.tid, gcMetric: 0, totalMetric: 0 });
+            }
+            const thread = threadMap.get(threadKey)!;
+            thread.totalMetric += ev.metric;
+
+            if (!ev.gc) { continue; }
+
+            thread.gcMetric += ev.metric;
+
+            const seen = new Set<string>();
+            for (let i = 0; i < ev.frameKeys.length; i++) {
+                const key = ev.frameKeys[i];
+                if (seen.has(key)) { continue; }
+                seen.add(key);
+                frameAll.set(key, (frameAll.get(key) ?? 0) + ev.metric);
+                if (i === ev.frameKeys.length - 1) {
+                    frameOwn.set(key, (frameOwn.get(key) ?? 0) + ev.metric);
+                }
+            }
+        }
+
+        const threads: GCThreadSummary[] = [...threadMap.values()]
+            .filter(t => t.gcMetric > 0)
+            .map(t => ({
+                pid: t.pid,
+                tid: t.tid,
+                gcFraction: t.gcMetric / t.totalMetric,
+            }))
+            .sort((a, b) => b.gcFraction - a.gcFraction);
+
+        if (threads.length === 0) {
+            this._view!.webview.postMessage({ noGC: true });
+            return;
+        }
+
+        const denom = stats.overallTotal || 1;
+
+        const topFrames: GCFrameItem[] = [...frameAll.entries()]
+            .map(([key, totalMetric]) => {
+                const topStats = stats.top.get(key);
+                // Safely split key into module + scope: module is everything up to the
+                // last ':', scope is what follows (Python names won't contain '/').
+                const lastColon = key.lastIndexOf(':');
+                return {
+                    key,
+                    scope: topStats?.scope ?? (lastColon >= 0 ? key.slice(lastColon + 1) : key),
+                    module: topStats?.module ?? (lastColon >= 0 ? key.slice(0, lastColon) : ''),
+                    line: topStats?.minLine ?? 0,
+                    gcOwn: (frameOwn.get(key) ?? 0) / denom,
+                    gcTotal: totalMetric / denom,
+                };
+            })
+            .sort((a, b) => b.gcOwn - a.gcOwn);
+
+        this._view!.webview.postMessage({ threads, topFrames });
+    }
+
+    private _getHtml(webview: vscode.Webview, stats: AustinStats | null): string {
+        const hasData = stats !== null;
+        const hasGC   = hasData && stats.gcEvents.some(e => e.gc);
+        const initMsg = !hasData
+            ? 'No profiling data loaded.'
+            : hasGC
+                ? ''   // will be replaced by _postData immediately
+                : 'No GC data available in this profile. Enable GC collection with the GC toggle in the status bar.';
+        const initActionsDisplay = hasData ? 'none' : '';
+        const scriptUri = webview.asWebviewUri(
+            vscode.Uri.joinPath(this._extensionUri, 'media', 'gctop.js')
+        );
+        const codiconsUri = webview.asWebviewUri(
+            vscode.Uri.joinPath(this._extensionUri, 'node_modules', '@vscode/codicons', 'dist', 'codicon.css')
+        );
+
+        return `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" type="text/css" href="${codiconsUri}">
+    <style>
+        * { box-sizing: border-box; }
+        body {
+            padding: 0;
+            margin: 0;
+            font-size: var(--vscode-font-size, 12px);
+            font-family: var(--vscode-font-family, sans-serif);
+            color: var(--vscode-foreground);
+            background: transparent;
+            overflow-x: hidden;
+        }
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            table-layout: auto;
+        }
+        thead {
+            position: sticky;
+            top: var(--toolbar-h, 32px);
+            background: var(--vscode-sideBar-background, var(--vscode-editor-background));
+            z-index: 1;
+        }
+        th {
+            text-align: left;
+            padding: 5px 6px;
+            border-bottom: 1px solid var(--vscode-panel-border, #444);
+            font-weight: 600;
+            font-size: 0.9em;
+            white-space: nowrap;
+        }
+        th[data-col] { cursor: pointer; user-select: none; }
+        th[data-col]:hover { background: var(--vscode-list-hoverBackground); }
+        th.desc::after { content: " ▼"; font-size: 9px; }
+        th.asc::after  { content: " ▲"; font-size: 9px; }
+        td {
+            padding: 3px 4px;
+            border-bottom: 1px solid var(--vscode-list-inactiveSelectionBackground, rgba(128,128,128,0.1));
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            vertical-align: middle;
+        }
+        .frame-row > td { cursor: pointer; }
+        .frame-row:hover > td { background: var(--vscode-list-hoverBackground); }
+        col.func { width: 100%; }
+        .bar-row { display: flex; align-items: center; gap: 4px; }
+        .bar-bg {
+            flex: 0 0 24px;
+            height: 5px;
+            background: var(--vscode-progressBar-background, rgba(128,128,128,0.2));
+            border-radius: 3px;
+            overflow: hidden;
+        }
+        .bar-fill { height: 5px; border-radius: 3px; background: var(--vscode-descriptionForeground); opacity: 0.4; }
+        .bar-fill[style] { opacity: 1; }
+        .pct {
+            width: 40px;
+            text-align: right;
+            font-variant-numeric: tabular-nums;
+            font-family: var(--vscode-editor-font-family, monospace);
+            flex-shrink: 0;
+            font-size: var(--vscode-editor-font-size, 1em);
+        }
+        .func { font-family: var(--vscode-editor-font-family, monospace); font-size: var(--vscode-editor-font-size, 1em); }
+        .scope-name {
+            font-family: var(--vscode-editor-font-family, monospace);
+            font-size: var(--vscode-editor-font-size, 1em);
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+        .scope-module {
+            margin-left: 6px;
+            font-size: 0.85em;
+            color: var(--vscode-descriptionForeground);
+        }
+        /* Thread summary section */
+        #thread-summary {
+            padding: 6px 8px 4px 8px;
+            border-bottom: 1px solid var(--vscode-panel-border, #444);
+        }
+        .thread-row {
+            display: flex;
+            align-items: center;
+            gap: 6px;
+            margin-bottom: 4px;
+            cursor: pointer;
+            border-radius: 3px;
+            padding: 1px 2px;
+        }
+        .thread-row:hover {
+            background: var(--vscode-list-hoverBackground);
+        }
+        .thread-label {
+            font-size: 0.85em;
+            color: var(--vscode-descriptionForeground);
+            flex-shrink: 0;
+            width: 110px;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+        .thread-bar-bg {
+            flex: 1;
+            height: 6px;
+            background: rgba(128,128,128,0.15);
+            border-radius: 3px;
+            overflow: hidden;
+        }
+        .thread-bar-fill {
+            height: 6px;
+            border-radius: 3px;
+            background: var(--vscode-descriptionForeground);
+            opacity: 0.4;
+        }
+        .thread-bar-fill[style] { opacity: 1; }
+        .thread-pct {
+            font-size: 0.85em;
+            font-variant-numeric: tabular-nums;
+            font-family: var(--vscode-editor-font-family, monospace);
+            flex-shrink: 0;
+            width: 38px;
+            text-align: right;
+        }
+        /* Toolbar */
+        .toolbar {
+            display: flex;
+            align-items: center;
+            gap: 4px;
+            padding: 4px 6px;
+            border-bottom: 1px solid var(--vscode-panel-border, #444);
+            user-select: none;
+            position: sticky;
+            top: 0;
+            z-index: 2;
+            background: var(--vscode-sideBar-background, var(--vscode-editor-background));
+        }
+        .filter-wrap {
+            flex: 1;
+            min-width: 0;
+            position: relative;
+            display: flex;
+            align-items: center;
+        }
+        #filter-input {
+            width: 100%;
+            background: rgba(128,128,128,0.1);
+            border: 1px solid rgba(128,128,128,0.25);
+            border-radius: 3px;
+            color: var(--vscode-foreground);
+            font-size: 0.9em;
+            font-family: inherit;
+            padding: 2px 22px 2px 6px;
+            height: 20px;
+            outline: none;
+        }
+        #filter-input:focus { border-color: var(--vscode-focusBorder, rgba(0,120,215,0.8)); }
+        #filter-input::placeholder { color: var(--vscode-descriptionForeground); opacity: 0.6; }
+        #filter-clear {
+            position: absolute;
+            right: 3px;
+            display: none;
+            align-items: center;
+            justify-content: center;
+            width: 14px;
+            height: 14px;
+            padding: 0;
+            border: none;
+            background: none;
+            cursor: pointer;
+            color: var(--vscode-descriptionForeground);
+            border-radius: 2px;
+            opacity: 0.6;
+            line-height: 1;
+        }
+        #filter-clear:hover { opacity: 1; background: var(--vscode-list-hoverBackground); }
+        #filter-clear.visible { display: flex; }
+        #live-dot {
+            width: 8px;
+            height: 8px;
+            border-radius: 50%;
+            background: #e74c3c;
+            flex-shrink: 0;
+            display: none;
+            margin-left: 2px;
+        }
+        #live-dot.active { display: block; animation: live-pulse 1.4s ease-in-out infinite; }
+        @keyframes live-pulse {
+            0%, 100% { opacity: 1; }
+            50%       { opacity: 0.3; }
+        }
+        .empty {
+            padding: 24px 16px;
+            color: var(--vscode-descriptionForeground);
+            text-align: center;
+            font-style: italic;
+        }
+        .open-btn {
+            display: inline-block;
+            padding: 4px 14px;
+            background: var(--vscode-button-background);
+            color: var(--vscode-button-foreground);
+            border: none;
+            border-radius: 2px;
+            cursor: pointer;
+            font-size: 11px;
+            font-weight: 600;
+            letter-spacing: 0.06em;
+        }
+        .open-btn:hover { background: var(--vscode-button-hoverBackground); }
+        .empty-actions {
+            display: flex;
+            flex-wrap: wrap;
+            justify-content: center;
+            margin-top: 10px;
+            gap: 4px;
+        }
+        #loading {
+            display: none;
+            position: fixed;
+            inset: 0;
+            align-items: center;
+            justify-content: center;
+            background: rgba(0,0,0,0.12);
+            z-index: 10;
+        }
+        #loading.active { display: flex; }
+        @keyframes spin { to { transform: rotate(360deg); } }
+        .spinner {
+            width: 20px;
+            height: 20px;
+            border: 2px solid rgba(128,128,128,0.25);
+            border-top-color: var(--vscode-progressBar-background, #007acc);
+            border-radius: 50%;
+            animation: spin 0.7s linear infinite;
+        }
+    </style>
+</head>
+<body>
+    <div id="loading"><div class="spinner"></div></div>
+    <div class="toolbar">
+        <div class="filter-wrap">
+            <input id="filter-input" type="text" placeholder="Filter…" autocomplete="off" spellcheck="false" />
+            <button id="filter-clear" title="Clear filter">
+                <svg width="10" height="10" viewBox="0 0 10 10" fill="currentColor">
+                    <line x1="1.5" y1="1.5" x2="8.5" y2="8.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+                    <line x1="8.5" y1="1.5" x2="1.5" y2="8.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+                </svg>
+            </button>
+        </div>
+        <span id="live-dot" title="Live session active"></span>
+    </div>
+    <div id="empty" class="empty">
+        <div id="empty-msg">${initMsg}</div>
+        <div id="empty-actions" class="empty-actions" style="display:${initActionsDisplay}">
+            <button class="open-btn" id="open-btn">OPEN</button>
+            <button class="open-btn" id="attach-btn">ATTACH</button>
+        </div>
+    </div>
+    <div id="content" style="display:none">
+        <div id="thread-summary"></div>
+        <table id="table">
+            <colgroup>
+                <col class="own">
+                <col class="total">
+                <col class="func">
+            </colgroup>
+            <thead>
+                <tr>
+                    <th data-col="gcOwn" class="desc">Own GC</th>
+                    <th data-col="gcTotal">Total GC</th>
+                    <th data-col="scope">Scope</th>
+                </tr>
+            </thead>
+            <tbody id="tbody"></tbody>
+        </table>
+    </div>
+    <script src="${scriptUri}"></script>
+</body>
+</html>`;
+    }
+}

--- a/src/providers/mcp.ts
+++ b/src/providers/mcp.ts
@@ -46,6 +46,20 @@ const TOOLS = [
             additionalProperties: false,
         },
     },
+    {
+        name: 'get_gc_data',
+        description: 'Returns garbage collector activity data. Includes per-thread GC time fractions and the top functions that were on the stack while the GC was running, ranked by own GC time. Returns an empty result if GC data collection was not enabled for this session (use the GC toggle in the status bar to enable it).',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                limit: {
+                    type: 'number',
+                    description: 'Maximum number of top GC frames to return. Omit for all.',
+                },
+            },
+            additionalProperties: false,
+        },
+    },
 ];
 
 // ---------------------------------------------------------------------------
@@ -197,6 +211,8 @@ export class AustinMcpServer {
                 return this._getCallStacks(args.depth as number | undefined);
             case 'get_metadata':
                 return this._getMetadata();
+            case 'get_gc_data':
+                return this._getGCData(args.limit as number | undefined);
             default:
                 return [{ type: 'text', text: `Unknown tool: ${name}` }];
         }
@@ -234,6 +250,76 @@ export class AustinMcpServer {
         };
         for (const [k, v] of stats.metadata) { meta[k] = v; }
         return [{ type: 'text', text: JSON.stringify(meta, null, 2) }];
+    }
+
+    private _getGCData(limit?: number): Array<{ type: string; text: string }> {
+        const stats = this._stats!;
+
+        if (!stats.gcEvents.length) {
+            return [{ type: 'text', text: JSON.stringify({ available: false, reason: 'No GC data in this profile. Enable GC collection with the GC toggle in the status bar.' }) }];
+        }
+
+        // Accumulate per-thread and per-frame GC metrics from the event log
+        const threadMap = new Map<string, { pid: number; tid: string; gcMetric: number; totalMetric: number }>();
+        const frameOwn = new Map<string, number>();
+        const frameAll = new Map<string, number>();
+
+        for (const ev of stats.gcEvents) {
+            if (ev.metric <= 0) { continue; }
+            const threadKey = `${ev.pid}:${ev.tid}`;
+            if (!threadMap.has(threadKey)) {
+                threadMap.set(threadKey, { pid: ev.pid, tid: ev.tid, gcMetric: 0, totalMetric: 0 });
+            }
+            const thread = threadMap.get(threadKey)!;
+            thread.totalMetric += ev.metric;
+
+            if (!ev.gc) { continue; }
+            thread.gcMetric += ev.metric;
+
+            const seen = new Set<string>();
+            for (let i = 0; i < ev.frameKeys.length; i++) {
+                const key = ev.frameKeys[i];
+                if (seen.has(key)) { continue; }
+                seen.add(key);
+                frameAll.set(key, (frameAll.get(key) ?? 0) + ev.metric);
+                if (i === ev.frameKeys.length - 1) {
+                    frameOwn.set(key, (frameOwn.get(key) ?? 0) + ev.metric);
+                }
+            }
+        }
+
+        const threads = [...threadMap.values()]
+            .filter(t => t.gcMetric > 0)
+            .map(t => ({
+                pid: t.pid,
+                tid: t.tid,
+                gcPct: parseFloat((t.gcMetric / t.totalMetric * 100).toFixed(2)),
+            }))
+            .sort((a, b) => b.gcPct - a.gcPct);
+
+        if (threads.length === 0) {
+            return [{ type: 'text', text: JSON.stringify({ available: false, reason: 'GC data was collected but no GC activity was recorded.' }) }];
+        }
+
+        const denom = stats.overallTotal || 1;
+        let frames = [...frameAll.entries()]
+            .map(([key, totalMetric]) => {
+                const topStats = stats.top.get(key);
+                const lastColon = key.lastIndexOf(':');
+                return {
+                    scope:    topStats?.scope  ?? (lastColon >= 0 ? key.slice(lastColon + 1) : key),
+                    module:   topStats?.module ?? (lastColon >= 0 ? key.slice(0, lastColon)  : ''),
+                    line:     topStats?.minLine ?? 0,
+                    ownGcPct:   parseFloat(((frameOwn.get(key) ?? 0) / denom * 100).toFixed(2)),
+                    totalGcPct: parseFloat((totalMetric / denom * 100).toFixed(2)),
+                };
+            })
+            .sort((a, b) => b.ownGcPct - a.ownGcPct);
+
+        // eslint-disable-next-line eqeqeq
+        if (limit != null && limit > 0) { frames = frames.slice(0, limit); }
+
+        return [{ type: 'text', text: JSON.stringify({ available: true, threads, frames }, null, 2) }];
     }
 
     private _error(

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -21,6 +21,7 @@ export class AustinRuntimeSettings {
         const austinMode: AustinMode = AustinRuntimeSettings.config.get("mode", DEFAULT_MODE);
         const austinLineStats: AustinLineStats = AustinRuntimeSettings.config.get("lineStats", DEFAULT_LINE_STATS);
         const austinChildren: boolean = AustinRuntimeSettings.config.get("children", false);
+        const austinGC: boolean = AustinRuntimeSettings.config.get("gc", false);
 
         this.settings = {
             path: austinPath,
@@ -28,6 +29,7 @@ export class AustinRuntimeSettings {
             interval: austinInterval,
             lineStats: austinLineStats,
             children: austinChildren,
+            gc: austinGC,
         };
     }
 
@@ -75,6 +77,14 @@ export class AustinRuntimeSettings {
 
     public static setChildren(children: boolean) {
         AustinRuntimeSettings.config.update("children", children, vscode.ConfigurationTarget.Global);
+    }
+
+    public static getGC(): boolean {
+        return AustinRuntimeSettings.get().settings.gc;
+    }
+
+    public static setGC(gc: boolean) {
+        AustinRuntimeSettings.config.update("gc", gc, vscode.ConfigurationTarget.Global);
     }
 
 }

--- a/src/test/suite/gcspans.test.ts
+++ b/src/test/suite/gcspans.test.ts
@@ -1,0 +1,412 @@
+import * as assert from 'assert';
+import { AustinStats } from '../../model';
+import { computeGCSpans, GC_MIN_FRACTION } from '../../providers/flamegraph';
+import '../../stringExtension';
+import '../../mapExtension';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build an AustinStats with a sequence of (gc, metric, frames?) events on
+ *  a single thread (pid=1, tid='T1') unless overridden. */
+function makeStats(
+    events: Array<{ gc: boolean; metric: number; frames?: Array<{ module: string; scope: string; line?: number }>; tid?: string }>,
+    pid = 1,
+): AustinStats {
+    const stats = new AustinStats();
+    for (const ev of events) {
+        const frames = (ev.frames ?? []).map(f => ({ module: f.module, scope: f.scope, line: f.line ?? 1 }));
+        stats.update(pid, ev.tid ?? 'T1', frames, ev.metric, ev.gc);
+    }
+    return stats;
+}
+
+
+// ---------------------------------------------------------------------------
+// computeGCSpans — basic span building
+// ---------------------------------------------------------------------------
+suite('computeGCSpans — basic span building', () => {
+
+    test('returns empty array when there are no events', () => {
+        const stats = new AustinStats();
+        assert.deepStrictEqual(computeGCSpans(stats), []);
+    });
+
+    test('returns empty array when no events have gc=true', () => {
+        const stats = makeStats([
+            { gc: false, metric: 100 },
+            { gc: false, metric: 200 },
+        ]);
+        assert.deepStrictEqual(computeGCSpans(stats), []);
+    });
+
+    test('produces one thread entry for a single gc span', () => {
+        const stats = makeStats([
+            { gc: false, metric: 100 },
+            { gc: true,  metric: 100 },
+            { gc: false, metric: 100 },
+        ]);
+        const result = computeGCSpans(stats);
+        assert.strictEqual(result.length, 1);
+        assert.strictEqual(result[0].threadKey, '1:T1');
+        assert.strictEqual(result[0].label, 'P1 TT1');
+        assert.strictEqual(result[0].spans.length, 1);
+    });
+
+    test('merges contiguous gc=true events into a single span', () => {
+        const stats = makeStats([
+            { gc: false, metric: 100 },
+            { gc: true,  metric: 50 },
+            { gc: true,  metric: 50 },
+            { gc: false, metric: 100 },
+        ]);
+        const result = computeGCSpans(stats);
+        assert.strictEqual(result[0].spans.length, 1);
+        assert.strictEqual(result[0].spans[0].durationFraction, 100 / 300);
+    });
+
+    test('produces separate spans for non-contiguous gc runs', () => {
+        const stats = makeStats([
+            { gc: true,  metric: 100 },
+            { gc: false, metric: 100 },
+            { gc: true,  metric: 100 },
+        ]);
+        const result = computeGCSpans(stats);
+        assert.strictEqual(result[0].spans.length, 2);
+    });
+
+    test('a gc span at the very end of the stream is captured', () => {
+        const stats = makeStats([
+            { gc: false, metric: 100 },
+            { gc: true,  metric: 100 },
+        ]);
+        const result = computeGCSpans(stats);
+        assert.strictEqual(result[0].spans.length, 1);
+    });
+});
+
+
+// ---------------------------------------------------------------------------
+// computeGCSpans — span fractions
+// ---------------------------------------------------------------------------
+suite('computeGCSpans — span fractions', () => {
+
+    test('startFraction is correct for a mid-stream span', () => {
+        // 200 non-gc, 100 gc → startFraction = 200/300
+        const stats = makeStats([
+            { gc: false, metric: 200 },
+            { gc: true,  metric: 100 },
+        ]);
+        const span = computeGCSpans(stats)[0].spans[0];
+        assert.ok(Math.abs(span.startFraction - 200 / 300) < 1e-9);
+    });
+
+    test('durationFraction is correct', () => {
+        const stats = makeStats([
+            { gc: false, metric: 100 },
+            { gc: true,  metric: 50 },
+            { gc: false, metric: 50 },
+        ]);
+        const span = computeGCSpans(stats)[0].spans[0];
+        assert.ok(Math.abs(span.durationFraction - 50 / 200) < 1e-9);
+    });
+
+    test('durationPct is the pre-formatted percentage string', () => {
+        const stats = makeStats([
+            { gc: false, metric: 500 },
+            { gc: true,  metric: 500 },
+        ]);
+        const span = computeGCSpans(stats)[0].spans[0];
+        assert.strictEqual(span.durationPct, '50.0');
+    });
+
+    test('startFraction is 0 when gc starts immediately', () => {
+        const stats = makeStats([
+            { gc: true, metric: 100 },
+            { gc: false, metric: 100 },
+        ]);
+        const span = computeGCSpans(stats)[0].spans[0];
+        assert.strictEqual(span.startFraction, 0);
+    });
+});
+
+
+// ---------------------------------------------------------------------------
+// computeGCSpans — minimum fraction filter
+// ---------------------------------------------------------------------------
+suite('computeGCSpans — minimum fraction filter', () => {
+
+    test(`drops spans below ${GC_MIN_FRACTION * 100}% of thread total`, () => {
+        // total = 100000; span = 99 → fraction = 0.00099 < 0.001
+        const stats = makeStats([
+            { gc: false, metric: 99901 },
+            { gc: true,  metric: 99 },
+        ]);
+        const result = computeGCSpans(stats);
+        assert.deepStrictEqual(result, []);
+    });
+
+    test('keeps spans at exactly the minimum fraction', () => {
+        // total = 100000; span = 100 → fraction = 0.001 == GC_MIN_FRACTION
+        const stats = makeStats([
+            { gc: false, metric: 99900 },
+            { gc: true,  metric: 100 },
+        ]);
+        const result = computeGCSpans(stats);
+        assert.strictEqual(result.length, 1);
+        assert.strictEqual(result[0].spans.length, 1);
+    });
+
+    test('events with metric <= 0 do not contribute to total', () => {
+        const stats = makeStats([
+            { gc: false, metric: 0 },
+            { gc: true,  metric: 100 },
+        ]);
+        // totalMetric = 100; span = 100 → fraction = 1.0 — should be kept
+        const result = computeGCSpans(stats);
+        assert.strictEqual(result.length, 1);
+    });
+});
+
+
+// ---------------------------------------------------------------------------
+// computeGCSpans — top frame contributors
+// ---------------------------------------------------------------------------
+suite('computeGCSpans — top frame contributors', () => {
+
+    test('span has no top frames when stack is empty during gc', () => {
+        const stats = makeStats([{ gc: true, metric: 100 }]);
+        const span = computeGCSpans(stats)[0].spans[0];
+        assert.strictEqual(span.topFrames.length, 0);
+    });
+
+    test('only the leaf (innermost) frame is attributed', () => {
+        const stats = makeStats([{
+            gc: true,
+            metric: 100,
+            frames: [
+                { module: '/a.py', scope: 'outer' },
+                { module: '/a.py', scope: 'inner' },
+            ],
+        }]);
+        const span = computeGCSpans(stats)[0].spans[0];
+        assert.strictEqual(span.topFrames.length, 1);
+        assert.strictEqual(span.topFrames[0].scope, 'inner');
+    });
+
+    test('top frames are sorted by metric descending', () => {
+        const stats = makeStats([
+            { gc: true, metric: 100, frames: [{ module: '/a.py', scope: 'rarer' }] },
+            { gc: true, metric: 200, frames: [{ module: '/a.py', scope: 'rarer' }, { module: '/b.py', scope: 'common' }] },
+            { gc: true, metric: 300, frames: [{ module: '/a.py', scope: 'rarer' }, { module: '/c.py', scope: 'dominant' }] },
+        ]);
+        const span = computeGCSpans(stats)[0].spans[0];
+        assert.strictEqual(span.topFrames[0].scope, 'dominant');
+        assert.strictEqual(span.topFrames[1].scope, 'common');
+        assert.strictEqual(span.topFrames[2].scope, 'rarer');
+    });
+
+    test('at most 3 top frames are returned', () => {
+        const frames = ['a', 'b', 'c', 'd'].map(s => ({ module: '/m.py', scope: s }));
+        const stats = makeStats(
+            frames.map(f => ({ gc: true, metric: 100, frames: [f] }))
+        );
+        const span = computeGCSpans(stats)[0].spans[0];
+        assert.ok(span.topFrames.length <= 3);
+    });
+
+    test('leaf-frame fractions sum to at most 100% within a span', () => {
+        const stats = makeStats([
+            { gc: true, metric: 50, frames: [{ module: '/a.py', scope: 'fn1' }] },
+            { gc: true, metric: 30, frames: [{ module: '/b.py', scope: 'fn2' }] },
+            { gc: true, metric: 20, frames: [{ module: '/c.py', scope: 'fn3' }] },
+        ]);
+        const span = computeGCSpans(stats)[0].spans[0];
+        const total = span.topFrames.reduce((s, f) => s + f.fraction, 0);
+        assert.ok(total <= 1.0 + 1e-9, `fractions summed to ${total}, expected ≤ 1`);
+    });
+});
+
+
+// ---------------------------------------------------------------------------
+// computeGCSpans — multi-thread
+// ---------------------------------------------------------------------------
+suite('computeGCSpans — multi-thread', () => {
+
+    test('produces separate entries for separate threads', () => {
+        const stats = new AustinStats();
+        stats.update(1, 'T1', [], 100, true);
+        stats.update(1, 'T2', [], 100, true);
+        const result = computeGCSpans(stats);
+        assert.strictEqual(result.length, 2);
+        const keys = result.map(r => r.threadKey).sort();
+        assert.deepStrictEqual(keys, ['1:T1', '1:T2']);
+    });
+
+    test('span fractions are per-thread, not cross-thread', () => {
+        const stats = new AustinStats();
+        // T1: 900 non-gc + 100 gc  → fraction = 0.1
+        stats.update(1, 'T1', [], 900, false);
+        stats.update(1, 'T1', [], 100, true);
+        // T2: 100 non-gc + 900 gc  → fraction = 0.9
+        stats.update(1, 'T2', [], 100, false);
+        stats.update(1, 'T2', [], 900, true);
+
+        const result = computeGCSpans(stats);
+        const t1 = result.find(r => r.threadKey === '1:T1')!;
+        const t2 = result.find(r => r.threadKey === '1:T2')!;
+
+        assert.ok(Math.abs(t1.spans[0].durationFraction - 0.1) < 1e-9);
+        assert.ok(Math.abs(t2.spans[0].durationFraction - 0.9) < 1e-9);
+    });
+
+    test('a thread with no gc events does not appear in results', () => {
+        const stats = new AustinStats();
+        stats.update(1, 'T1', [], 100, false);
+        stats.update(1, 'T2', [], 100, true);
+        const result = computeGCSpans(stats);
+        assert.strictEqual(result.length, 1);
+        assert.strictEqual(result[0].threadKey, '1:T2');
+    });
+
+    test('separate process IDs produce separate thread entries', () => {
+        const stats = new AustinStats();
+        stats.update(1, 'T1', [], 100, true);
+        stats.update(2, 'T1', [], 100, true);
+        const result = computeGCSpans(stats);
+        assert.strictEqual(result.length, 2);
+        const keys = result.map(r => r.threadKey).sort();
+        assert.deepStrictEqual(keys, ['1:T1', '2:T1']);
+    });
+
+    test('tid containing colons is preserved in threadKey and label', () => {
+        // Some platforms use thread IDs that look like "T1:sub", producing a
+        // threadKey of "1:T1:sub".  The label must reconstruct the full tid.
+        const stats = new AustinStats();
+        stats.update(1, 'T1:sub', [], 100, true);
+        const result = computeGCSpans(stats);
+        assert.strictEqual(result[0].threadKey, '1:T1:sub');
+        assert.strictEqual(result[0].label, 'P1 TT1:sub');
+    });
+});
+
+
+// ---------------------------------------------------------------------------
+// computeGCSpans — zero-metric event handling
+// ---------------------------------------------------------------------------
+suite('computeGCSpans — zero-metric event handling', () => {
+
+    test('a thread whose events all have metric <= 0 is omitted', () => {
+        const stats = new AustinStats();
+        stats.update(1, 'T1', [], 0,  true);
+        stats.update(1, 'T1', [], -5, true);
+        assert.deepStrictEqual(computeGCSpans(stats), []);
+    });
+
+    test('gc=true event with metric <= 0 does not start a span', () => {
+        const stats = new AustinStats();
+        stats.update(1, 'T1', [], 0,   true);  // skipped — no span started
+        stats.update(1, 'T1', [], 100, false); // non-gc with metric > 0
+        // totalMetric = 100, no gc span → no thread entry
+        assert.deepStrictEqual(computeGCSpans(stats), []);
+    });
+
+    test('gc=true event with metric <= 0 does not extend an active span', () => {
+        const stats = new AustinStats();
+        stats.update(1, 'T1', [], 100, true);  // starts span, duration = 100
+        stats.update(1, 'T1', [], 0,   true);  // skipped — duration stays 100
+        stats.update(1, 'T1', [], 100, false); // closes span; total = 200
+        const span = computeGCSpans(stats)[0].spans[0];
+        assert.ok(Math.abs(span.durationFraction - 100 / 200) < 1e-9);
+    });
+
+    test('gc=false event with metric <= 0 does not close an active span', () => {
+        // The zero-metric event is skipped entirely, so two gc runs separated
+        // only by a zero-metric non-gc event are merged into one span.
+        const stats = new AustinStats();
+        stats.update(1, 'T1', [], 100, true);  // span starts
+        stats.update(1, 'T1', [], 0,   false); // skipped — span stays open
+        stats.update(1, 'T1', [], 100, true);  // span continues
+        stats.update(1, 'T1', [], 100, false); // closes span; total = 300
+        const result = computeGCSpans(stats);
+        // One span, not two
+        assert.strictEqual(result[0].spans.length, 1);
+        assert.ok(Math.abs(result[0].spans[0].durationFraction - 200 / 300) < 1e-9);
+    });
+});
+
+
+// ---------------------------------------------------------------------------
+// computeGCSpans — all spans filtered
+// ---------------------------------------------------------------------------
+suite('computeGCSpans — all spans filtered out', () => {
+
+    test('thread is omitted when all its spans are below the min fraction', () => {
+        // Two tiny gc spans, both < 0.1% of total; thread should not appear.
+        const stats = new AustinStats();
+        stats.update(1, 'T1', [], 999900, false);
+        stats.update(1, 'T1', [], 50,     true);   // 0.005% — below threshold
+        stats.update(1, 'T1', [], 999900, false);
+        stats.update(1, 'T1', [], 50,     true);   // 0.005% — below threshold
+        assert.deepStrictEqual(computeGCSpans(stats), []);
+    });
+
+    test('only spans above the threshold are kept; others are dropped', () => {
+        const stats = new AustinStats();
+        // total ≈ 200100; big span = 100 (0.05% < 0.1%), small span = 100100 (>50%)
+        stats.update(1, 'T1', [], 100,   true);   // below threshold
+        stats.update(1, 'T1', [], 99900, false);
+        stats.update(1, 'T1', [], 100100, true);  // well above threshold
+        const result = computeGCSpans(stats);
+        assert.strictEqual(result.length, 1);
+        assert.strictEqual(result[0].spans.length, 1);
+        // The surviving span is the large one
+        assert.ok(result[0].spans[0].durationFraction > 0.5);
+    });
+});
+
+
+// ---------------------------------------------------------------------------
+// computeGCSpans — scope/module resolution fallback
+// ---------------------------------------------------------------------------
+suite('computeGCSpans — scope/module resolution', () => {
+
+    test('resolves scope and module from stats.top when available', () => {
+        // makeStats calls stats.update() which populates stats.top
+        const stats = makeStats([{
+            gc: true,
+            metric: 100,
+            frames: [{ module: '/app/mod.py', scope: 'my_func' }],
+        }]);
+        const frame = computeGCSpans(stats)[0].spans[0].topFrames[0];
+        assert.strictEqual(frame.scope, 'my_func');
+        assert.strictEqual(frame.module, '/app/mod.py');
+    });
+
+    test('falls back to splitting frameKey on last colon when not in stats.top', () => {
+        // Inject a gcEvent manually with a key that has no corresponding stats.top entry
+        const stats = new AustinStats();
+        // Push a raw gcEvent that bypasses update() so stats.top stays empty
+        (stats.gcEvents as any[]).push({
+            pid: 1, tid: 'T1', gc: true, metric: 100,
+            frameKeys: ['/some/module.py:some_func'],
+        });
+        const result = computeGCSpans(stats);
+        const frame = result[0].spans[0].topFrames[0];
+        assert.strictEqual(frame.scope, 'some_func');
+        assert.strictEqual(frame.module, '/some/module.py');
+    });
+
+    test('frameKey with no colon falls back to key as scope and empty module', () => {
+        const stats = new AustinStats();
+        (stats.gcEvents as any[]).push({
+            pid: 1, tid: 'T1', gc: true, metric: 100,
+            frameKeys: ['no_colon_key'],
+        });
+        const result = computeGCSpans(stats);
+        const frame = result[0].spans[0].topFrames[0];
+        assert.strictEqual(frame.scope, 'no_colon_key');
+        assert.strictEqual(frame.module, '');
+    });
+});

--- a/src/test/suite/mcp.test.ts
+++ b/src/test/suite/mcp.test.ts
@@ -49,6 +49,17 @@ async function startedServer(stats: AustinStats): Promise<AustinMcpServer> {
     return server;
 }
 
+/** Build stats with GC events directly (text parser strips GC frames). */
+function makeGCStats(): AustinStats {
+    const stats = new AustinStats();
+    // 300 units total: 100 non-gc, 100 gc on fn1, 100 gc on fn2
+    stats.update(1, 'T1', [{ module: '/a.py', scope: 'fn1', line: 1 }], 100, false);
+    stats.update(1, 'T1', [{ module: '/a.py', scope: 'fn1', line: 1 }], 100, true);
+    stats.update(1, 'T1', [{ module: '/b.py', scope: 'fn2', line: 1 }], 100, true);
+    stats.refresh();
+    return stats;
+}
+
 // ---------------------------------------------------------------------------
 // Suite
 // ---------------------------------------------------------------------------
@@ -120,7 +131,7 @@ suite('AustinMcpServer', () => {
         assert.strictEqual(res, null);
     });
 
-    test('tools/list returns all three tools', async () => {
+    test('tools/list returns all four tools', async () => {
         const stats = await makeStats('P1;T1;/a.py:fn:1 100\n');
         server = await startedServer(stats);
         const res = await post(server.port, { jsonrpc: '2.0', method: 'tools/list', id: 3 }) as Record<string, unknown>;
@@ -129,6 +140,7 @@ suite('AustinMcpServer', () => {
         assert.ok(names.includes('get_top'));
         assert.ok(names.includes('get_call_stacks'));
         assert.ok(names.includes('get_metadata'));
+        assert.ok(names.includes('get_gc_data'));
     });
 
     test('unknown method returns error -32601', async () => {
@@ -279,5 +291,95 @@ suite('AustinMcpServer', () => {
 
         const content = (res.result as Record<string, unknown>).content as Array<{ type: string; text: string }>;
         assert.ok(content[0].text.includes('Unknown tool'));
+    });
+
+    // --- get_gc_data ---------------------------------------------------------
+
+    test('get_gc_data returns available:false when no GC events exist', async () => {
+        const stats = await makeStats('P1;T1;/a.py:fn:1 100\n');
+        server = await startedServer(stats);
+        const res = await post(server.port, {
+            jsonrpc: '2.0', method: 'tools/call', id: 13,
+            params: { name: 'get_gc_data', arguments: {} },
+        }) as Record<string, unknown>;
+
+        const content = (res.result as Record<string, unknown>).content as Array<{ type: string; text: string }>;
+        const data = JSON.parse(content[0].text) as Record<string, unknown>;
+        assert.strictEqual(data.available, false);
+    });
+
+    test('get_gc_data returns available:true with threads and frames when GC data present', async () => {
+        server = await startedServer(makeGCStats());
+        const res = await post(server.port, {
+            jsonrpc: '2.0', method: 'tools/call', id: 14,
+            params: { name: 'get_gc_data', arguments: {} },
+        }) as Record<string, unknown>;
+
+        const content = (res.result as Record<string, unknown>).content as Array<{ type: string; text: string }>;
+        const data = JSON.parse(content[0].text) as Record<string, unknown>;
+        assert.strictEqual(data.available, true);
+        assert.ok(Array.isArray(data.threads), 'threads should be an array');
+        assert.ok(Array.isArray(data.frames),  'frames should be an array');
+    });
+
+    test('get_gc_data threads include pid, tid, and gcPct', async () => {
+        server = await startedServer(makeGCStats());
+        const res = await post(server.port, {
+            jsonrpc: '2.0', method: 'tools/call', id: 15,
+            params: { name: 'get_gc_data', arguments: {} },
+        }) as Record<string, unknown>;
+
+        const content = (res.result as Record<string, unknown>).content as Array<{ type: string; text: string }>;
+        const { threads } = JSON.parse(content[0].text) as { threads: Array<Record<string, unknown>> };
+        assert.strictEqual(threads.length, 1);
+        assert.ok('pid'   in threads[0]);
+        assert.ok('tid'   in threads[0]);
+        assert.ok('gcPct' in threads[0]);
+        // 200 gc / 300 total ≈ 66.67%
+        assert.ok((threads[0].gcPct as number) > 60 && (threads[0].gcPct as number) < 70);
+    });
+
+    test('get_gc_data frames include scope, module, ownGcPct, totalGcPct, line', async () => {
+        server = await startedServer(makeGCStats());
+        const res = await post(server.port, {
+            jsonrpc: '2.0', method: 'tools/call', id: 16,
+            params: { name: 'get_gc_data', arguments: {} },
+        }) as Record<string, unknown>;
+
+        const content = (res.result as Record<string, unknown>).content as Array<{ type: string; text: string }>;
+        const { frames } = JSON.parse(content[0].text) as { frames: Array<Record<string, unknown>> };
+        assert.ok(frames.length > 0);
+        const frame = frames[0];
+        assert.ok('scope'      in frame);
+        assert.ok('module'     in frame);
+        assert.ok('ownGcPct'   in frame);
+        assert.ok('totalGcPct' in frame);
+        assert.ok('line'       in frame);
+    });
+
+    test('get_gc_data frames are sorted by ownGcPct descending', async () => {
+        server = await startedServer(makeGCStats());
+        const res = await post(server.port, {
+            jsonrpc: '2.0', method: 'tools/call', id: 17,
+            params: { name: 'get_gc_data', arguments: {} },
+        }) as Record<string, unknown>;
+
+        const content = (res.result as Record<string, unknown>).content as Array<{ type: string; text: string }>;
+        const { frames } = JSON.parse(content[0].text) as { frames: Array<{ ownGcPct: number }> };
+        for (let i = 1; i < frames.length; i++) {
+            assert.ok(frames[i - 1].ownGcPct >= frames[i].ownGcPct, 'frames should be sorted descending');
+        }
+    });
+
+    test('get_gc_data respects limit argument', async () => {
+        server = await startedServer(makeGCStats());
+        const res = await post(server.port, {
+            jsonrpc: '2.0', method: 'tools/call', id: 18,
+            params: { name: 'get_gc_data', arguments: { limit: 1 } },
+        }) as Record<string, unknown>;
+
+        const content = (res.result as Record<string, unknown>).content as Array<{ type: string; text: string }>;
+        const { frames } = JSON.parse(content[0].text) as { frames: unknown[] };
+        assert.strictEqual(frames.length, 1);
     });
 });

--- a/src/test/suite/model.test.ts
+++ b/src/test/suite/model.test.ts
@@ -385,6 +385,87 @@ suite('AustinStats — paused flag', () => {
 
 
 // ---------------------------------------------------------------------------
+// AustinStats — GC event collection
+// ---------------------------------------------------------------------------
+suite('AustinStats — gcEvents', () => {
+
+    test('gcEvents is empty on construction', () => {
+        const stats = new AustinStats();
+        assert.strictEqual(stats.gcEvents.length, 0);
+    });
+
+    test('update() appends a gcEvent for every call', () => {
+        const stats = new AustinStats();
+        stats.update(1, 'T1', [], 100);
+        stats.update(1, 'T1', [], 200);
+        assert.strictEqual(stats.gcEvents.length, 2);
+    });
+
+    test('gc flag defaults to false', () => {
+        const stats = new AustinStats();
+        stats.update(1, 'T1', [], 100);
+        assert.strictEqual(stats.gcEvents[0].gc, false);
+    });
+
+    test('gc flag is stored when true', () => {
+        const stats = new AustinStats();
+        stats.update(1, 'T1', [], 100, true);
+        assert.strictEqual(stats.gcEvents[0].gc, true);
+    });
+
+    test('pid and tid are recorded correctly', () => {
+        const stats = new AustinStats();
+        stats.update(42, 'T99', [], 100);
+        assert.strictEqual(stats.gcEvents[0].pid, 42);
+        assert.strictEqual(stats.gcEvents[0].tid, 'T99');
+    });
+
+    test('metric is recorded correctly', () => {
+        const stats = new AustinStats();
+        stats.update(1, 'T1', [], 777);
+        assert.strictEqual(stats.gcEvents[0].metric, 777);
+    });
+
+    test('frameKeys are built as module:scope', () => {
+        const stats = new AustinStats();
+        const frames = [
+            { module: '/a.py', scope: 'outer', line: 1 },
+            { module: '/b.py', scope: 'inner', line: 2 },
+        ];
+        stats.update(1, 'T1', frames, 100);
+        assert.deepStrictEqual(stats.gcEvents[0].frameKeys, ['/a.py:outer', '/b.py:inner']);
+    });
+
+    test('temporal order is preserved across multiple updates', () => {
+        const stats = new AustinStats();
+        stats.update(1, 'T1', [], 10, false);
+        stats.update(1, 'T1', [], 20, true);
+        stats.update(1, 'T1', [], 30, false);
+        assert.strictEqual(stats.gcEvents[0].gc, false);
+        assert.strictEqual(stats.gcEvents[1].gc, true);
+        assert.strictEqual(stats.gcEvents[2].gc, false);
+    });
+
+    test('clear() resets gcEvents to empty', () => {
+        const stats = new AustinStats();
+        stats.update(1, 'T1', [], 100, true);
+        stats.clear();
+        assert.strictEqual(stats.gcEvents.length, 0);
+    });
+
+    test('gcEvents from multiple threads are interleaved in call order', () => {
+        const stats = new AustinStats();
+        stats.update(1, 'T1', [], 10, true);
+        stats.update(1, 'T2', [], 20, false);
+        stats.update(1, 'T1', [], 30, false);
+        assert.strictEqual(stats.gcEvents[0].tid, 'T1');
+        assert.strictEqual(stats.gcEvents[1].tid, 'T2');
+        assert.strictEqual(stats.gcEvents[2].tid, 'T1');
+    });
+});
+
+
+// ---------------------------------------------------------------------------
 // AustinStats — error callbacks
 // ---------------------------------------------------------------------------
 suite('AustinStats — error callbacks', () => {

--- a/src/test/suite/mojo.test.ts
+++ b/src/test/suite/mojo.test.ts
@@ -390,10 +390,13 @@ suite('MojoParser — special frame types', () => {
         assert.ok(Math.abs(stats.top.get('/b.py:bar')!.total - 5 / 35) < 1e-9);
     });
 
-    test('GC frame is pushed onto stack', () => {
+    test('GC event sets gc=true on the resulting gcEvent', () => {
+        // MOJO_EVENT.gc (7) marks the following sample as a GC sample;
+        // it no longer injects a synthetic ":GC" frame into the stack.
         const bytes = buildStreamWithEvent([vi(7)]);  // MOJO_EVENT.gc
         const stats = parseWith(bytes);
-        assert.ok(stats.top.has(':GC'));
+        assert.ok(!stats.top.has(':GC'), 'synthetic GC frame must not appear in top');
+        assert.ok(stats.gcEvents.some(e => e.gc), 'at least one gcEvent should have gc=true');
     });
 
     test('kernel frame is pushed with module="kernel"', () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,4 +16,5 @@ export class AustinSettings {
     interval: number = 100;
     lineStats: AustinLineStats = AustinLineStats.PERCENT;
     children: boolean = false;
+    gc: boolean = false;
 }

--- a/src/utils/commandFactory.ts
+++ b/src/utils/commandFactory.ts
@@ -39,6 +39,7 @@ export function getAustinCommand(
     if (_mode === AustinMode.CpuTime) { _args.push("-c"); }
     if (_mode === AustinMode.Memory) { _args.push("-m"); }
     if (settings.children) { _args.push("-C"); }
+    if (settings.gc) { _args.push("-g"); }
     if (austinArgs) { _args = _args.concat(austinArgs); }
     if (pid !== undefined) {
         _args.push("-p", `${pid}`);

--- a/src/utils/mojo.ts
+++ b/src/utils/mojo.ts
@@ -194,6 +194,7 @@ export class MojoParser {
                                 `${currentIid}:${currentTid}`,
                                 currentStack,
                                 Number(mode === "memory" ? currentMemoryMetric! : currentTimeMetric!),
+                                currentGC,
                             );
                             // Save the current stack for back-attribution under the OLD key
                             previousStacks.set(currentStackKey!, currentStack);
@@ -244,7 +245,7 @@ export class MojoParser {
                         break;
 
                     case MOJO_EVENT.gc:
-                        currentStack.push(specialFrame("GC"));
+                        currentGC = true;
                         break;
 
                     case MOJO_EVENT.idle:
@@ -278,6 +279,7 @@ export class MojoParser {
                         `${currentIid}:${currentTid}`,
                         currentStack,
                         Number(mode === "memory" ? currentMemoryMetric! : currentTimeMetric!),
+                        currentGC,
                     );
                 }
                 return;
@@ -306,6 +308,7 @@ export class StreamingMojoParser {
     private mode: string | null = null;
     private previousStacks = new Map<string, FrameObject[]>();
     private invalidFrame = false;
+    private currentGC = false;
 
     constructor(private readonly stats: AustinStats) {}
 
@@ -398,6 +401,7 @@ export class StreamingMojoParser {
                         `${this.currentIid}:${this.currentTid}`,
                         this.currentStack,
                         Number(this.mode === "memory" ? this.currentMemoryMetric! : this.currentTimeMetric!),
+                        this.currentGC,
                     );
                     this.previousStacks.set(this.currentStackKey!, this.currentStack);
                 }
@@ -409,6 +413,7 @@ export class StreamingMojoParser {
                 this.currentTimeMetric = null;
                 this.currentMemoryMetric = null;
                 this.invalidFrame = false;
+                this.currentGC = false;
                 break;
             }
             case MOJO_EVENT.frame: {
@@ -439,7 +444,7 @@ export class StreamingMojoParser {
                 break;
             }
             case MOJO_EVENT.gc:
-                this.currentStack.push(specialFrame("GC"));
+                this.currentGC = true;
                 break;
             case MOJO_EVENT.idle:
                 break;
@@ -498,6 +503,7 @@ export class StreamingMojoParser {
                 `${this.currentIid}:${this.currentTid}`,
                 this.currentStack,
                 Number(this.mode === "memory" ? this.currentMemoryMetric! : this.currentTimeMetric!),
+                this.currentGC,
             );
         }
     }


### PR DESCRIPTION
- GC Activity swimlane panel in the flame graph view shows per-thread GC spans as proportional time blocks; span and highlight colours match the profile mode (CPU/wall/memory). Hovering shows top-3 leaf frame contributors; clicking a thread label zooms the flame graph to that thread.

- GC Top sidebar panel lists functions on the stack during GC collection, ranked by own GC time, with per-thread summaries, a filter bar, and sortable columns. Thread rows and frame rows are clickable.

- GC status bar toggle enables/disables GC collection (-g/--gc flag), persisted across sessions.

- GCEvent log in AustinStats tracks per-sample GC state; MOJO and text format parsers propagate the gc flag; GC synthetic frame removed from the flame graph hierarchy.

<img width="1581" height="1116" alt="Screenshot 2026-04-07 at 18 43 30" src="https://github.com/user-attachments/assets/5bbe49c8-648a-48a4-b19d-22b0ad327109" />
