### PR TITLE
fix: prevent Austin profile command from becoming default run button action

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
         {
           "command": "austin-vscode.profile",
           "when": "resourceLangId == python",
-          "group": "navigation"
+          "group": "navigation@3"
         }
       ]
     },


### PR DESCRIPTION
Use navigation@3 group to sort after built-in Python run/debug entries.

<img width="457" height="257" alt="Screenshot 2026-04-07 at 18 56 11" src="https://github.com/user-attachments/assets/26429817-be54-457a-a376-da84253f3ca8" />

Fixes #103.