### PR TITLE
feat(mcp): add load/search/highlight tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Change Log
 
+## [1.3.0]
+
+### MCP enhancements
+
+- Added a `load_profile` MCP tool that lets an AI agent open a profile file by
+  path. The file is loaded and the flame graph view is revealed automatically,
+  so the agent can display profiling results to the user without any manual
+  interaction.
+
+- Added a `focus_flamegraph` MCP tool that lets an AI agent highlight and zoom
+  to a specific node in the flame graph, for AI-assisted flame graph
+  navigation.
+
+- Added a `search_flamegraph` MCP tool that highlights every frame whose
+  function name contains a given term across all threads and call chains.
+  Unlike `focus_flamegraph`, which zooms to a single node by exact path key,
+  this is useful for showing all occurrences of a function at once.
+
+- `get_call_stacks` increased the default expansion depth from 5 to 15 to reach
+  past framework boilerplate into user code, and accepts a `threshold` parameter
+  (in total%) to prune call-stack branches that contribute less than the given
+  percentage of total profiling time — keeping the response compact for large
+  profiles. The tool description now explains how to read `total` as flame graph
+  width and use `module` paths to identify user code versus third-party
+  libraries.
+
+
 ## [1.2.0]
 
 ### GC Activity

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -87,6 +87,26 @@ export async function activate(context: vscode.ExtensionContext) {
 	callStackProvider.onFrameSelected((pathKey) => flameGraphViewProvider.focusFrame(pathKey));
 	gcTopProvider.onThreadSelected((threadKey) => flameGraphViewProvider.focusThread(threadKey));
 
+	mcpServer.setActions({
+		loadFile: (path) => {
+			try {
+				stats.readFromFile(path);
+			} catch (e) {
+				vscode.window.showErrorMessage(`Failed to load profile: ${(e instanceof Error) ? e.message : e}`);
+				return;
+			}
+			vscode.commands.executeCommand('austin-vscode.flame-graph.focus');
+		},
+		focusFrame: (pathKey) => {
+			flameGraphViewProvider.focusFrame(pathKey);
+			vscode.commands.executeCommand('austin-vscode.flame-graph.focus');
+		},
+		searchFrames: (term) => {
+			flameGraphViewProvider.search(term);
+			vscode.commands.executeCommand('austin-vscode.flame-graph.focus');
+		},
+	});
+
 	context.subscriptions.push(
 		vscode.window.registerWebviewViewProvider(
 			FlameGraphViewProvider.viewType,

--- a/src/providers/mcp.ts
+++ b/src/providers/mcp.ts
@@ -1,5 +1,12 @@
 import * as http from 'http';
+import { existsSync } from 'fs';
 import { AustinStats, TopStats } from '../model';
+
+export interface McpActions {
+    loadFile: (path: string) => void;
+    focusFrame: (pathKey: string) => void;
+    searchFrames: (term: string) => void;
+}
 
 const MCP_PROTOCOL_VERSION = '2024-11-05';
 const SERVER_NAME = 'austin-vscode';
@@ -25,13 +32,33 @@ const TOOLS = [
     },
     {
         name: 'get_call_stacks',
-        description: 'Returns the process→thread→function call-stack tree. Each node has scope, module, own%, total%, and children.',
+        description: [
+            'Returns the process→thread→function call-stack tree for flame graph analysis.',
+            'Each node has: scope (function name), module (source file path), own (fraction of',
+            'total profiling time spent directly in this function body), total (fraction spent in',
+            'this function and everything it calls — this is the flame graph width, i.e. the',
+            '"plateau" size), children, and pathKey (pass directly to focus_flamegraph).',
+            '',
+            'To find the most interesting plateau in user code:',
+            '1. Follow the child with the highest total down from the thread node.',
+            '2. Stop when own becomes significant (the function itself is doing real work) or',
+            '   when children fragment into many branches each with low total.',
+            '3. Prefer nodes whose module does not contain "site-packages" or "/lib/python"',
+            '   (those are third-party or stdlib frames — keep descending past them).',
+            '',
+            'Use a larger depth for framework-heavy code (Django, Flask, pytest, etc. add many',
+            'layers of library frames before reaching user code).',
+        ].join(' '),
         inputSchema: {
             type: 'object',
             properties: {
                 depth: {
                     type: 'number',
-                    description: 'Maximum tree depth to expand (default: 5).',
+                    description: 'Maximum tree depth to expand (default: 15). Increase for deeply nested or framework-heavy call stacks.',
+                },
+                threshold: {
+                    type: 'number',
+                    description: 'Minimum total% a node must account for to be included (default: 0 — no filtering). For example, 0.1 drops every call-stack branch that accounts for less than 0.1% of total profiling time, keeping the response compact for large profiles.',
                 },
             },
             additionalProperties: false,
@@ -60,12 +87,58 @@ const TOOLS = [
             additionalProperties: false,
         },
     },
+    {
+        name: 'search_flamegraph',
+        description: 'Highlights every flame graph frame whose function name contains the given term (case-sensitive substring match) and reveals the flame graph view. Unlike focus_flamegraph, which zooms to a single node by exact path key, this highlights all occurrences of a function across every thread and call chain. Use this to show the user all places a given function appears — for example after identifying a hot function via get_call_stacks.',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                term: {
+                    type: 'string',
+                    description: 'Substring to match against function names in the flame graph.',
+                },
+            },
+            required: ['term'],
+            additionalProperties: false,
+        },
+    },
+    {
+        name: 'load_profile',
+        description: 'Loads an Austin profile file from the given path and opens it in the flamegraph view for the user to inspect. Call this after collecting profiling data with Austin to display the results. The file is loaded asynchronously; call get_metadata shortly after to confirm the data is available.',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                path: {
+                    type: 'string',
+                    description: 'Absolute path to the Austin profile file (.austin, .aprof, or .mojo).',
+                },
+            },
+            required: ['path'],
+            additionalProperties: false,
+        },
+    },
+    {
+        name: 'focus_flamegraph',
+        description: 'Highlights a specific node in the flamegraph by its path key, zooming it into view for the user. The path key is the slash-separated hierarchy built from the call-stack tree returned by get_call_stacks: each node\'s pathKey is formed by joining ancestor scope fields with "/", e.g. "Process 123/Thread 456/outer_func/inner_func". If the exact key is not found, frames whose path contains the key text are still highlighted.',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                key: {
+                    type: 'string',
+                    description: 'Path key of the flamegraph node to focus (e.g. "Process 123/Thread 456/my_function").',
+                },
+            },
+            required: ['key'],
+            additionalProperties: false,
+        },
+    },
 ];
 
 // ---------------------------------------------------------------------------
 // Serialisation helpers
 // ---------------------------------------------------------------------------
 interface CallStackNode {
+    pathKey: string;
     scope: string | null;
     module: string | null;
     own: number;
@@ -73,15 +146,20 @@ interface CallStackNode {
     children: CallStackNode[];
 }
 
-function serializeCallStackNode(node: TopStats, depth: number): CallStackNode {
+function serializeCallStackNode(node: TopStats, depth: number, parentKey: string, threshold: number): CallStackNode {
+    const myKey = parentKey ? `${parentKey}/${node.scope ?? ''}` : (node.scope ?? '');
+    const children = depth > 0
+        ? [...node.callees.values()]
+            .filter(child => child.total * 100 >= threshold)
+            .map(child => serializeCallStackNode(child, depth - 1, myKey, threshold))
+        : [];
     return {
+        pathKey: myKey,
         scope: node.scope,
         module: node.module,
         own: parseFloat((node.own * 100).toFixed(2)),
         total: parseFloat((node.total * 100).toFixed(2)),
-        children: depth > 0
-            ? [...node.callees.values()].map(child => serializeCallStackNode(child, depth - 1))
-            : [],
+        children,
     };
 }
 
@@ -91,6 +169,12 @@ function serializeCallStackNode(node: TopStats, depth: number): CallStackNode {
 export class AustinMcpServer {
     private _httpServer: http.Server | null = null;
     private _stats: AustinStats | null = null;
+    private _actions: McpActions | null = null;
+
+    /** Registers callbacks for UI actions the MCP tools can trigger. */
+    setActions(actions: McpActions): void {
+        this._actions = actions;
+    }
 
     /** Starts the server on an OS-assigned port. Resolves once the port is known. */
     start(): Promise<void> {
@@ -200,6 +284,11 @@ export class AustinMcpServer {
     }
 
     private _callTool(name: string, args: Record<string, unknown>): Array<{ type: string; text: string }> {
+        // These tools work regardless of whether profiling data is loaded.
+        if (name === 'load_profile') {
+            return this._loadProfile(args.path as string | undefined);
+        }
+
         if (!this._stats || this._stats.overallTotal === 0) {
             return [{ type: 'text', text: 'No profiling data available yet. Run a profiling session first.' }];
         }
@@ -208,14 +297,54 @@ export class AustinMcpServer {
             case 'get_top':
                 return this._getTop(args.limit as number | undefined);
             case 'get_call_stacks':
-                return this._getCallStacks(args.depth as number | undefined);
+                return this._getCallStacks(args.depth as number | undefined, args.threshold as number | undefined);
             case 'get_metadata':
                 return this._getMetadata();
             case 'get_gc_data':
                 return this._getGCData(args.limit as number | undefined);
+            case 'focus_flamegraph':
+                return this._focusFlamegraph(args.key as string | undefined);
+            case 'search_flamegraph':
+                return this._searchFlamegraph(args.term as string | undefined);
             default:
                 return [{ type: 'text', text: `Unknown tool: ${name}` }];
         }
+    }
+
+    private _loadProfile(path?: string): Array<{ type: string; text: string }> {
+        if (!path) {
+            return [{ type: 'text', text: 'Missing required argument: path' }];
+        }
+        if (!existsSync(path)) {
+            return [{ type: 'text', text: `File not found: ${path}` }];
+        }
+        if (!this._actions) {
+            return [{ type: 'text', text: 'Profile loading is not available.' }];
+        }
+        this._actions.loadFile(path);
+        return [{ type: 'text', text: `Loading profile from ${path}. The flamegraph view will update once parsing is complete.` }];
+    }
+
+    private _focusFlamegraph(key?: string): Array<{ type: string; text: string }> {
+        if (!key) {
+            return [{ type: 'text', text: 'Missing required argument: key' }];
+        }
+        if (!this._actions) {
+            return [{ type: 'text', text: 'Flamegraph focus is not available.' }];
+        }
+        this._actions.focusFrame(key);
+        return [{ type: 'text', text: `Focused flamegraph node: ${key}` }];
+    }
+
+    private _searchFlamegraph(term?: string): Array<{ type: string; text: string }> {
+        if (!term) {
+            return [{ type: 'text', text: 'Missing required argument: term' }];
+        }
+        if (!this._actions) {
+            return [{ type: 'text', text: 'Flamegraph search is not available.' }];
+        }
+        this._actions.searchFrames(term);
+        return [{ type: 'text', text: `Searching flamegraph for: ${term}` }];
     }
 
     private _getTop(limit?: number): Array<{ type: string; text: string }> {
@@ -236,9 +365,11 @@ export class AustinMcpServer {
         return [{ type: 'text', text: JSON.stringify(result, null, 2) }];
     }
 
-    private _getCallStacks(depth: number = 5): Array<{ type: string; text: string }> {
+    private _getCallStacks(depth: number = 15, threshold: number = 0): Array<{ type: string; text: string }> {
         const stats = this._stats!;
-        const tree = [...stats.callStack.callees.values()].map(n => serializeCallStackNode(n, depth - 1));
+        const tree = [...stats.callStack.callees.values()]
+            .filter(n => n.total * 100 >= threshold)
+            .map(n => serializeCallStackNode(n, depth - 1, '', threshold));
         return [{ type: 'text', text: JSON.stringify(tree, null, 2) }];
     }
 

--- a/src/test/suite/mcp.test.ts
+++ b/src/test/suite/mcp.test.ts
@@ -1,5 +1,8 @@
 import * as assert from 'assert';
+import * as fs from 'fs';
 import * as http from 'http';
+import * as os from 'os';
+import * as path from 'path';
 import { Readable } from 'stream';
 import { AustinMcpServer } from '../../providers/mcp';
 import { AustinStats } from '../../model';
@@ -47,6 +50,13 @@ async function startedServer(stats: AustinStats): Promise<AustinMcpServer> {
     await server.start();
     server.update(stats);
     return server;
+}
+
+/** Creates a temp .austin file with the given content and returns its path. */
+function makeTmpAustinFile(content: string = 'P1;T1;/a.py:fn:1 100\n'): string {
+    const p = path.join(os.tmpdir(), `austin-mcp-test-${Math.random().toString(36).slice(2)}.austin`);
+    fs.writeFileSync(p, content);
+    return p;
 }
 
 /** Build stats with GC events directly (text parser strips GC frames). */
@@ -131,7 +141,7 @@ suite('AustinMcpServer', () => {
         assert.strictEqual(res, null);
     });
 
-    test('tools/list returns all four tools', async () => {
+    test('tools/list returns all tools', async () => {
         const stats = await makeStats('P1;T1;/a.py:fn:1 100\n');
         server = await startedServer(stats);
         const res = await post(server.port, { jsonrpc: '2.0', method: 'tools/list', id: 3 }) as Record<string, unknown>;
@@ -141,6 +151,9 @@ suite('AustinMcpServer', () => {
         assert.ok(names.includes('get_call_stacks'));
         assert.ok(names.includes('get_metadata'));
         assert.ok(names.includes('get_gc_data'));
+        assert.ok(names.includes('load_profile'));
+        assert.ok(names.includes('focus_flamegraph'));
+        assert.ok(names.includes('search_flamegraph'));
     });
 
     test('unknown method returns error -32601', async () => {
@@ -381,5 +394,295 @@ suite('AustinMcpServer', () => {
         const content = (res.result as Record<string, unknown>).content as Array<{ type: string; text: string }>;
         const { frames } = JSON.parse(content[0].text) as { frames: unknown[] };
         assert.strictEqual(frames.length, 1);
+    });
+
+    // --- get_call_stacks pathKey --------------------------------------------
+
+    test('get_call_stacks nodes include pathKey', async () => {
+        const stats = await makeStats('P1;T1;/a.py:fn:1 100\n');
+        server = await startedServer(stats);
+        const res = await post(server.port, {
+            jsonrpc: '2.0', method: 'tools/call', id: 19,
+            params: { name: 'get_call_stacks', arguments: {} },
+        }) as Record<string, unknown>;
+
+        const content = (res.result as Record<string, unknown>).content as Array<{ type: string; text: string }>;
+        type Node = { pathKey: string; children: Node[] };
+        const tree = JSON.parse(content[0].text) as Node[];
+        const processNode = tree[0];
+        assert.strictEqual(processNode.pathKey, 'Process 1');
+        const threadNode = processNode.children[0];
+        assert.ok(threadNode.pathKey.startsWith('Process 1/Thread '), 'thread pathKey should be nested under process');
+        const frameNode = threadNode.children[0];
+        assert.strictEqual(frameNode.pathKey, threadNode.pathKey + '/fn');
+    });
+
+    test('get_call_stacks pathKey is consistent across nested children', async () => {
+        const stats = await makeStats('P1;T1;/a.py:outer:1;/a.py:inner:2 100\n');
+        server = await startedServer(stats);
+        const res = await post(server.port, {
+            jsonrpc: '2.0', method: 'tools/call', id: 20,
+            params: { name: 'get_call_stacks', arguments: {} },
+        }) as Record<string, unknown>;
+
+        const content = (res.result as Record<string, unknown>).content as Array<{ type: string; text: string }>;
+        type Node = { pathKey: string; children: Node[] };
+        const tree = JSON.parse(content[0].text) as Node[];
+        const frameNode = tree[0].children[0].children[0];
+        const nestedNode = frameNode.children[0];
+        assert.ok(nestedNode.pathKey.startsWith(frameNode.pathKey + '/'), 'nested pathKey should extend parent');
+    });
+
+    // --- load_profile -------------------------------------------------------
+
+    test('load_profile bypasses the no-data guard', async () => {
+        const stats = new AustinStats(); // empty — overallTotal === 0
+        server = await startedServer(stats);
+        server.setActions({ loadFile: () => {}, focusFrame: () => {}, searchFrames: () => {} });
+        const tmpFile = makeTmpAustinFile();
+        try {
+            const res = await post(server.port, {
+                jsonrpc: '2.0', method: 'tools/call', id: 21,
+                params: { name: 'load_profile', arguments: { path: tmpFile } },
+            }) as Record<string, unknown>;
+            const content = (res.result as Record<string, unknown>).content as Array<{ type: string; text: string }>;
+            assert.ok(!content[0].text.includes('No profiling data'));
+        } finally {
+            fs.unlinkSync(tmpFile);
+        }
+    });
+
+    test('load_profile returns error for missing path argument', async () => {
+        const stats = new AustinStats();
+        server = await startedServer(stats);
+        server.setActions({ loadFile: () => {}, focusFrame: () => {}, searchFrames: () => {} });
+        const res = await post(server.port, {
+            jsonrpc: '2.0', method: 'tools/call', id: 22,
+            params: { name: 'load_profile', arguments: {} },
+        }) as Record<string, unknown>;
+        const content = (res.result as Record<string, unknown>).content as Array<{ type: string; text: string }>;
+        assert.ok(content[0].text.toLowerCase().includes('missing'));
+    });
+
+    test('load_profile returns error when file does not exist', async () => {
+        const stats = new AustinStats();
+        server = await startedServer(stats);
+        server.setActions({ loadFile: () => {}, focusFrame: () => {}, searchFrames: () => {} });
+        const res = await post(server.port, {
+            jsonrpc: '2.0', method: 'tools/call', id: 23,
+            params: { name: 'load_profile', arguments: { path: '/no/such/file.austin' } },
+        }) as Record<string, unknown>;
+        const content = (res.result as Record<string, unknown>).content as Array<{ type: string; text: string }>;
+        assert.ok(content[0].text.toLowerCase().includes('not found'));
+    });
+
+    test('load_profile invokes loadFile action with the given path', async () => {
+        const stats = new AustinStats();
+        server = await startedServer(stats);
+        const tmpFile = makeTmpAustinFile();
+        try {
+            let calledWith: string | null = null;
+            server.setActions({ loadFile: (p) => { calledWith = p; }, focusFrame: () => {}, searchFrames: () => {} });
+            await post(server.port, {
+                jsonrpc: '2.0', method: 'tools/call', id: 24,
+                params: { name: 'load_profile', arguments: { path: tmpFile } },
+            });
+            assert.strictEqual(calledWith, tmpFile);
+        } finally {
+            fs.unlinkSync(tmpFile);
+        }
+    });
+
+    test('load_profile returns not-available message when no actions are set', async () => {
+        const stats = new AustinStats();
+        server = await startedServer(stats);
+        // Deliberately do not call setActions
+        const tmpFile = makeTmpAustinFile();
+        try {
+            const res = await post(server.port, {
+                jsonrpc: '2.0', method: 'tools/call', id: 25,
+                params: { name: 'load_profile', arguments: { path: tmpFile } },
+            }) as Record<string, unknown>;
+            const content = (res.result as Record<string, unknown>).content as Array<{ type: string; text: string }>;
+            assert.ok(content[0].text.toLowerCase().includes('not available'));
+        } finally {
+            fs.unlinkSync(tmpFile);
+        }
+    });
+
+    // --- focus_flamegraph ---------------------------------------------------
+
+    test('focus_flamegraph hits no-data guard when no stats are loaded', async () => {
+        const stats = new AustinStats(); // empty
+        server = await startedServer(stats);
+        server.setActions({ loadFile: () => {}, focusFrame: () => {}, searchFrames: () => {} });
+        const res = await post(server.port, {
+            jsonrpc: '2.0', method: 'tools/call', id: 26,
+            params: { name: 'focus_flamegraph', arguments: { key: 'Process 1/Thread T1/fn' } },
+        }) as Record<string, unknown>;
+        const content = (res.result as Record<string, unknown>).content as Array<{ type: string; text: string }>;
+        assert.ok(content[0].text.includes('No profiling data'));
+    });
+
+    test('focus_flamegraph returns error for missing key argument', async () => {
+        const stats = await makeStats('P1;T1;/a.py:fn:1 100\n');
+        server = await startedServer(stats);
+        server.setActions({ loadFile: () => {}, focusFrame: () => {}, searchFrames: () => {} });
+        const res = await post(server.port, {
+            jsonrpc: '2.0', method: 'tools/call', id: 27,
+            params: { name: 'focus_flamegraph', arguments: {} },
+        }) as Record<string, unknown>;
+        const content = (res.result as Record<string, unknown>).content as Array<{ type: string; text: string }>;
+        assert.ok(content[0].text.toLowerCase().includes('missing'));
+    });
+
+    test('focus_flamegraph invokes focusFrame action with the given key', async () => {
+        const stats = await makeStats('P1;T1;/a.py:fn:1 100\n');
+        server = await startedServer(stats);
+        let calledWith: string | null = null;
+        server.setActions({ loadFile: () => {}, focusFrame: (k) => { calledWith = k; }, searchFrames: () => {} });
+        const key = 'Process 1/Thread T1/fn';
+        await post(server.port, {
+            jsonrpc: '2.0', method: 'tools/call', id: 28,
+            params: { name: 'focus_flamegraph', arguments: { key } },
+        });
+        assert.strictEqual(calledWith, key);
+    });
+
+    test('focus_flamegraph returns not-available message when no actions are set', async () => {
+        const stats = await makeStats('P1;T1;/a.py:fn:1 100\n');
+        server = await startedServer(stats);
+        // Deliberately do not call setActions
+        const res = await post(server.port, {
+            jsonrpc: '2.0', method: 'tools/call', id: 29,
+            params: { name: 'focus_flamegraph', arguments: { key: 'Process 1/Thread T1/fn' } },
+        }) as Record<string, unknown>;
+        const content = (res.result as Record<string, unknown>).content as Array<{ type: string; text: string }>;
+        assert.ok(content[0].text.toLowerCase().includes('not available'));
+    });
+
+    // --- get_call_stacks threshold ------------------------------------------
+
+    test('get_call_stacks threshold filters out low-contribution branches', async () => {
+        // heavy: 99 samples (~99%), light: 1 sample (~1%)
+        const stats = await makeStats(
+            'P1;T1;/a.py:heavy:1 99\n' +
+            'P1;T1;/a.py:light:1 1\n'
+        );
+        server = await startedServer(stats);
+        const res = await post(server.port, {
+            jsonrpc: '2.0', method: 'tools/call', id: 30,
+            params: { name: 'get_call_stacks', arguments: { threshold: 2 } },
+        }) as Record<string, unknown>;
+
+        const content = (res.result as Record<string, unknown>).content as Array<{ type: string; text: string }>;
+        const text = content[0].text;
+        assert.ok(text.includes('heavy'), 'heavy (99%) should survive the threshold');
+        assert.ok(!text.includes('light'), 'light (1%) should be pruned by threshold=2');
+    });
+
+    test('get_call_stacks threshold=0 keeps everything', async () => {
+        const stats = await makeStats(
+            'P1;T1;/a.py:heavy:1 99\n' +
+            'P1;T1;/a.py:light:1 1\n'
+        );
+        server = await startedServer(stats);
+        const res = await post(server.port, {
+            jsonrpc: '2.0', method: 'tools/call', id: 31,
+            params: { name: 'get_call_stacks', arguments: { threshold: 0 } },
+        }) as Record<string, unknown>;
+
+        const content = (res.result as Record<string, unknown>).content as Array<{ type: string; text: string }>;
+        const text = content[0].text;
+        assert.ok(text.includes('heavy'));
+        assert.ok(text.includes('light'), 'light should be kept when threshold=0');
+    });
+
+    test('get_call_stacks threshold prunes entire subtree of a low-contribution node', async () => {
+        // outer calls inner; outer has 1% total — both should be pruned
+        const stats = await makeStats(
+            'P1;T1;/a.py:heavy:1 99\n' +
+            'P1;T1;/a.py:outer:1;/a.py:inner:2 1\n'
+        );
+        server = await startedServer(stats);
+        const res = await post(server.port, {
+            jsonrpc: '2.0', method: 'tools/call', id: 32,
+            params: { name: 'get_call_stacks', arguments: { threshold: 2 } },
+        }) as Record<string, unknown>;
+
+        const content = (res.result as Record<string, unknown>).content as Array<{ type: string; text: string }>;
+        const text = content[0].text;
+        assert.ok(!text.includes('outer'), 'outer (1%) should be pruned');
+        assert.ok(!text.includes('inner'), 'inner should be pruned as part of outer\'s subtree');
+    });
+
+    // --- get_call_stacks default depth --------------------------------------
+
+    test('get_call_stacks expands significantly deeper than the old default', async () => {
+        // Build a 20-frame deep stack
+        const frames = Array.from({ length: 20 }, (_, i) => `/a.py:f${i}:${i + 1}`).join(';');
+        const stats = await makeStats(`P1;T1;${frames} 100\n`);
+        server = await startedServer(stats);
+        const res = await post(server.port, {
+            jsonrpc: '2.0', method: 'tools/call', id: 30,
+            params: { name: 'get_call_stacks', arguments: {} },
+        }) as Record<string, unknown>;
+
+        const content = (res.result as Record<string, unknown>).content as Array<{ type: string; text: string }>;
+        const text = content[0].text;
+        // depth=15: serializeCallStackNode starts at depth-1=14, consuming 2 levels for
+        // process+thread, leaving 13 levels for frames → f0..f12 are visible.
+        assert.ok(text.includes('"f12"'), 'depth=15 should reach frame f12');
+        // The old depth=5 only reached f2; f12 proves the new default is much deeper.
+        assert.ok(!text.includes('"f13"'), 'f13 should be just beyond the default depth');
+    });
+
+    // --- search_flamegraph --------------------------------------------------
+
+    test('search_flamegraph hits no-data guard when no stats are loaded', async () => {
+        const stats = new AustinStats();
+        server = await startedServer(stats);
+        server.setActions({ loadFile: () => {}, focusFrame: () => {}, searchFrames: () => {} });
+        const res = await post(server.port, {
+            jsonrpc: '2.0', method: 'tools/call', id: 31,
+            params: { name: 'search_flamegraph', arguments: { term: 'fn' } },
+        }) as Record<string, unknown>;
+        const content = (res.result as Record<string, unknown>).content as Array<{ type: string; text: string }>;
+        assert.ok(content[0].text.includes('No profiling data'));
+    });
+
+    test('search_flamegraph returns error for missing term argument', async () => {
+        const stats = await makeStats('P1;T1;/a.py:fn:1 100\n');
+        server = await startedServer(stats);
+        server.setActions({ loadFile: () => {}, focusFrame: () => {}, searchFrames: () => {} });
+        const res = await post(server.port, {
+            jsonrpc: '2.0', method: 'tools/call', id: 32,
+            params: { name: 'search_flamegraph', arguments: {} },
+        }) as Record<string, unknown>;
+        const content = (res.result as Record<string, unknown>).content as Array<{ type: string; text: string }>;
+        assert.ok(content[0].text.toLowerCase().includes('missing'));
+    });
+
+    test('search_flamegraph invokes searchFrames action with the given term', async () => {
+        const stats = await makeStats('P1;T1;/a.py:fn:1 100\n');
+        server = await startedServer(stats);
+        let calledWith: string | null = null;
+        server.setActions({ loadFile: () => {}, focusFrame: () => {}, searchFrames: (t) => { calledWith = t; } });
+        await post(server.port, {
+            jsonrpc: '2.0', method: 'tools/call', id: 33,
+            params: { name: 'search_flamegraph', arguments: { term: 'my_func' } },
+        });
+        assert.strictEqual(calledWith, 'my_func');
+    });
+
+    test('search_flamegraph returns not-available message when no actions are set', async () => {
+        const stats = await makeStats('P1;T1;/a.py:fn:1 100\n');
+        server = await startedServer(stats);
+        const res = await post(server.port, {
+            jsonrpc: '2.0', method: 'tools/call', id: 34,
+            params: { name: 'search_flamegraph', arguments: { term: 'fn' } },
+        }) as Record<string, unknown>;
+        const content = (res.result as Record<string, unknown>).content as Array<{ type: string; text: string }>;
+        assert.ok(content[0].text.toLowerCase().includes('not available'));
     });
 });


### PR DESCRIPTION
We add more MCP tools to the server to allow more autonomous flamegraph investigation and navigation from AI agents. In particular we expose tools to load an existing profile, search capabilities to highlight frames in the flame graph view, as well as the ability to highlight areas of interested based on profiling data analysis from the agent.