### PR TITLE
perf: replace path-string keys with rolling djb2 hash keys

### DIFF
--- a/media/callstack.js
+++ b/media/callstack.js
@@ -32,7 +32,7 @@
         } else if (msg.childrenFor !== undefined) {
             insertLazyChildren(msg.childrenFor, msg.children);
         } else if (msg.focus) {
-            if (syncToggle.checked) { focusPath(msg.focus.pathKey); }
+            if (syncToggle.checked) { focusPath(msg.focus.frameKey); }
         } else if (msg.live !== undefined) {
             liveDot.classList.toggle('active', !!msg.live);
         } else if (msg.error) {
@@ -73,9 +73,9 @@
 
     function restoreExpanded() {
         if (expandedPaths.size === 0) { return; }
-        document.querySelectorAll('tr[data-expandable][data-path-key]').forEach(tr => {
-            const pk = tr.dataset.pathKey;
-            if (!pk || !expandedPaths.has(pk)) { return; }
+        document.querySelectorAll('tr[data-expandable][data-frame-key]').forEach(tr => {
+            const fk = parseInt(tr.dataset.frameKey, 10);
+            if (isNaN(fk) || !expandedPaths.has(fk)) { return; }
             const rowId = tr.dataset.rowId;
             document.querySelectorAll(`tr[data-parent-id="${rowId}"]`).forEach(child => {
                 child.style.display = '';
@@ -101,7 +101,7 @@
             tr.style.display = 'none';
         }
         if (hasChildren) { tr.dataset.expandable = '1'; }
-        tr.dataset.pathKey = node.pathKey || '';
+        tr.dataset.frameKey = String(node.frameKey);
         if (node.childrenPending) { tr.dataset.childrenPending = '1'; }
 
         const indent = level * 10;
@@ -121,7 +121,7 @@
         tr.addEventListener('click', () => {
             if (node.module) { navigate(node.module, node.line); }
             if (hasChildren) { toggleRow(rowId); }
-            if (node.pathKey && syncToggle.checked) { vscode.postMessage({ pathKey: node.pathKey }); }
+            if (node.frameKey !== undefined && syncToggle.checked) { vscode.postMessage({ frameKey: node.frameKey }); }
         });
 
         if (typeof parent.appendChild === 'function') {
@@ -148,12 +148,12 @@
             expanded.delete(rowId);
             if (row) {
                 delete row.dataset.open;
-                if (row.dataset.pathKey) { expandedPaths.delete(row.dataset.pathKey); }
+                if (row.dataset.frameKey) { expandedPaths.delete(parseInt(row.dataset.frameKey, 10)); }
             }
         } else {
             if (row && row.dataset.childrenPending) {
                 // Children not yet loaded — request from extension
-                vscode.postMessage({ requestChildren: row.dataset.pathKey });
+                vscode.postMessage({ requestChildren: parseInt(row.dataset.frameKey, 10) });
                 return;
             }
             document.querySelectorAll(`tr[data-parent-id="${rowId}"]`).forEach(tr => {
@@ -162,7 +162,7 @@
             expanded.add(rowId);
             if (row) {
                 row.dataset.open = '1';
-                if (row.dataset.pathKey) { expandedPaths.add(row.dataset.pathKey); }
+                if (row.dataset.frameKey) { expandedPaths.add(parseInt(row.dataset.frameKey, 10)); }
             }
         }
     }
@@ -176,12 +176,12 @@
                 expanded.delete(childId);
                 delete tr.dataset.open;
             }
-            if (tr.dataset.pathKey) { expandedPaths.delete(tr.dataset.pathKey); }
+            if (tr.dataset.frameKey) { expandedPaths.delete(parseInt(tr.dataset.frameKey, 10)); }
         });
     }
 
-    function insertLazyChildren(parentPathKey, children) {
-        const parentRow = document.querySelector(`tr[data-path-key="${CSS.escape(parentPathKey)}"]`);
+    function insertLazyChildren(parentFrameKey, children) {
+        const parentRow = document.querySelector(`tr[data-frame-key="${parentFrameKey}"]`);
         if (!parentRow) { return; }
         const parentId = parentRow.dataset.rowId;
         const parentLevel = parseInt(parentRow.dataset.level || '0', 10);
@@ -209,7 +209,7 @@
         });
         expanded.add(parentId);
         parentRow.dataset.open = '1';
-        expandedPaths.add(parentPathKey);
+        expandedPaths.add(parentFrameKey);
     }
 
     function insertNodeBefore(tbody, refNode, node, parentId, level) {
@@ -222,7 +222,7 @@
         tr.dataset.parentId = parentId;
         tr.style.display = 'none';
         if (hasChildren) { tr.dataset.expandable = '1'; }
-        tr.dataset.pathKey = node.pathKey || '';
+        tr.dataset.frameKey = String(node.frameKey);
         if (node.childrenPending) { tr.dataset.childrenPending = '1'; }
 
         const indent = level * 10;
@@ -242,7 +242,7 @@
         tr.addEventListener('click', () => {
             if (node.module) { navigate(node.module, node.line); }
             if (hasChildren) { toggleRow(rowId); }
-            if (node.pathKey && syncToggle.checked) { vscode.postMessage({ pathKey: node.pathKey }); }
+            if (node.frameKey !== undefined && syncToggle.checked) { vscode.postMessage({ frameKey: node.frameKey }); }
         });
 
         tbody.insertBefore(tr, refNode || null);
@@ -287,11 +287,11 @@
         vscode.postMessage({ module, line });
     }
 
-    function focusPath(pathKey) {
-        if (!pathKey) { return; }
+    function focusPath(frameKey) {
+        if (frameKey === undefined || frameKey === null) { return; }
         let target = null;
-        for (const tr of document.querySelectorAll('tr[data-path-key]')) {
-            if (tr.dataset.pathKey === pathKey) { target = tr; break; }
+        for (const tr of document.querySelectorAll('tr[data-frame-key]')) {
+            if (parseInt(tr.dataset.frameKey, 10) === frameKey) { target = tr; break; }
         }
         if (!target) { return; }
 

--- a/media/flamegraph-utils.js
+++ b/media/flamegraph-utils.js
@@ -34,6 +34,23 @@
         return h;
     }
 
+    /**
+     * djb2-variant hash returning a 32-bit unsigned integer.
+     * Accepts an optional seed so callers can chain calls for path segments
+     * (rolling hash) without building intermediate path strings.
+     * Same algorithm used in src/utils/pathKey.ts for cross-boundary consistency.
+     * @param {string} text
+     * @param {number} [seed]
+     * @returns {number}
+     */
+    function hashPath(text, seed) {
+        let h = seed | 0;
+        for (let i = 0; i < text.length; i++) {
+            h = (((h << 5) + h) + text.charCodeAt(i)) | 0;
+        }
+        return h >>> 0;
+    }
+
     /** @param {any} node */
     function colorFor(node) {
         if (node.kind === 'process') { return hslToHex(120, hash(node.name) % 20, 70); }
@@ -92,5 +109,5 @@
         return metric + ' &nbsp;\u00B7&nbsp; ' + scope + file;
     }
 
-    return { hslToHex, hash, colorFor, esc, basename, isEmpty, formatValue, footerText };
+    return { hslToHex, hash, hashPath, colorFor, esc, basename, isEmpty, formatValue, footerText };
 }));

--- a/media/flamegraph.js
+++ b/media/flamegraph.js
@@ -5,14 +5,15 @@
 
     // ── Utilities (loaded from flamegraph-utils.js) ───────────────────────────
     // @ts-ignore
-    const { colorFor, basename, isEmpty, footerText, esc } = FlamegraphUtils;
+    const { colorFor, basename, isEmpty, footerText, esc, hashPath } = FlamegraphUtils;
 
-    /** @param {any} node @param {string} parentKey */
-    function addPathKeys(node, parentKey) {
-        const myKey = parentKey ? parentKey + '/' + node.name : node.name;
-        node.pathKey = myKey;
+    /** @param {any} node @param {number} parentHash */
+    function addPathKeys(node, parentHash) {
+        // Use node.key (module:scope for frames, bare name for process/thread) so that
+        // two functions with the same name in different modules get distinct frameKeys.
+        node.frameKey = hashPath(node.key, parentHash);
         if (node.children) {
-            for (const child of node.children) { addPathKeys(child, myKey); }
+            for (const child of node.children) { addPathKeys(child, node.frameKey); }
         }
     }
 
@@ -294,10 +295,10 @@
 
     function applySearch() {
         for (const f of frames) {
-            if (!searchTerm) { f.highlighted = false; continue; }
             if (searchMode === 'path') {
-                f.highlighted = f.node.pathKey === searchTerm;
+                f.highlighted = f.node.frameKey === searchTerm;
             } else {
+                if (!searchTerm) { f.highlighted = false; continue; }
                 f.highlighted = (f.node.name || '').indexOf(searchTerm) !== -1 ||
                     !!(f.node.file && f.node.file.indexOf(searchTerm) !== -1);
             }
@@ -308,14 +309,14 @@
     function loadData(hierarchy) {
         if (!hierarchy || isEmpty(hierarchy)) { return; }
         if (hierarchy.children) {
-            for (const child of hierarchy.children) { addPathKeys(child, ''); }
+            for (const child of hierarchy.children) { addPathKeys(child, 0); }
         }
         // Preserve zoom and search across live updates by re-finding the node
-        const prevZoomKey = zoomNode ? zoomNode.pathKey : null;
+        const prevZoomKey = zoomNode ? zoomNode.frameKey : null;
         rootNode = hierarchy;
         hoveredFrame = null;
-        if (prevZoomKey) {
-            zoomNode = findByPathKey(rootNode, prevZoomKey) || null;
+        if (prevZoomKey !== null && prevZoomKey !== undefined) {
+            zoomNode = findByKey(rootNode, prevZoomKey) || null;
         } else {
             zoomNode = null;
             searchTerm = '';
@@ -350,26 +351,26 @@
         render(canvas, ctx, frames, hoveredFrame, null, 1);
     }
 
-    /** @param {any} node @param {string} pathKey @returns {any} */
-    function findByPathKey(node, pathKey) {
-        if (node.pathKey === pathKey) { return node; }
+    /** @param {any} node @param {number} frameKey @returns {any} */
+    function findByKey(node, frameKey) {
+        if (node.frameKey === frameKey) { return node; }
         if (node.children) {
             for (const child of node.children) {
-                const found = findByPathKey(child, pathKey);
+                const found = findByKey(child, frameKey);
                 if (found) { return found; }
             }
         }
         return null;
     }
 
-    /** @param {string} pathKey */
-    function focusByPathKey(pathKey) {
+    /** @param {number} frameKey */
+    function focusByKey(frameKey) {
         if (!rootNode) { return; }
-        const target = findByPathKey(rootNode, pathKey);
+        const target = findByKey(rootNode, frameKey);
         // Set state in one shot to avoid double animation
         zoomNode = target || null;
         hoveredFrame = null;
-        searchTerm = pathKey;
+        searchTerm = frameKey;
         searchMode = 'path';
         rebuildAndRender(true);
         if (target) {
@@ -385,7 +386,7 @@
         if (!f) { return; }
         zoomTo(f.node);
         if (f.node.file) {
-            vscode.postMessage({ file: f.node.file, name: f.node.name, line: f.node.line, source: f.node.source });
+            vscode.postMessage({ file: f.node.file, name: f.node.name, line: f.node.line, source: f.node.source, frameKey: f.node.frameKey });
         }
     });
 
@@ -578,8 +579,8 @@
         } else if (msg.focusThread) {
             const node = findThreadNode(msg.focusThread);
             if (node) { zoomTo(node); }
-        } else if (msg.focus) {
-            focusByPathKey(msg.focus);
+        } else if (msg.focus !== undefined) {
+            focusByKey(msg.focus);
         } else if (msg.search) {
             setSearch(msg.search, 'text');
         } else if (msg.meta !== undefined) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -83,8 +83,8 @@ export async function activate(context: vscode.ExtensionContext) {
 		}
 	});
 
-	flameGraphViewProvider.onFrameSelected((pathKey) => callStackProvider.focusPath(pathKey));
-	callStackProvider.onFrameSelected((pathKey) => flameGraphViewProvider.focusFrame(pathKey));
+	flameGraphViewProvider.onFrameSelected((frameKey) => callStackProvider.focusPath(frameKey));
+	callStackProvider.onFrameSelected((frameKey) => flameGraphViewProvider.focusFrame(frameKey));
 	gcTopProvider.onThreadSelected((threadKey) => flameGraphViewProvider.focusThread(threadKey));
 
 	mcpServer.setActions({
@@ -97,8 +97,8 @@ export async function activate(context: vscode.ExtensionContext) {
 			}
 			vscode.commands.executeCommand('austin-vscode.flame-graph.focus');
 		},
-		focusFrame: (pathKey) => {
-			flameGraphViewProvider.focusFrame(pathKey);
+		focusFrame: (frameKey) => {
+			flameGraphViewProvider.focusFrame(frameKey);
 			vscode.commands.executeCommand('austin-vscode.flame-graph.focus');
 		},
 		searchFrames: (term) => {

--- a/src/providers/callstack.ts
+++ b/src/providers/callstack.ts
@@ -1,8 +1,9 @@
 import * as vscode from 'vscode';
 import { AustinStats, TopStats } from '../model';
+import { hashPath } from '../utils/pathKey';
 
 interface CallStackNode {
-    pathKey: string;
+    frameKey: number;
     scope: string;
     module: string | null;
     own: number;
@@ -19,19 +20,20 @@ function normalizeScope(scope: string): string {
     return type === 'P' ? `Process ${id}` : `Thread ${id}`;
 }
 
-function serializeNode(node: TopStats, parentPath: string, depth: number): CallStackNode {
+function serializeNode(node: TopStats, parentHash: number, depth: number): CallStackNode {
     const scope = normalizeScope(node.scope ?? '');
-    const pathKey = parentPath ? `${parentPath}/${scope}` : scope;
+    const key = node.module ? `${node.module}:${scope}` : scope;
+    const frameKey = hashPath(key, parentHash);
     const hasChildren = node.callees.size > 0;
     return {
-        pathKey,
+        frameKey,
         scope,
         module: node.module || null,
         own: node.own,
         total: node.total,
         line: node.minLine,
         children: depth > 0
-            ? [...node.callees.values()].map(child => serializeNode(child, pathKey, depth - 1))
+            ? [...node.callees.values()].map(child => serializeNode(child, frameKey, depth - 1))
             : [],
         childrenPending: hasChildren && depth <= 0,
     };
@@ -44,8 +46,8 @@ export class CallStackViewProvider implements vscode.WebviewViewProvider {
     private _view?: vscode.WebviewView;
     private _stats: AustinStats | null = null;
     private _initialized: boolean = false;
-    private _onFrameSelected?: (pathKey: string) => void;
-    private _nodeMap: Map<string, TopStats> = new Map();
+    private _onFrameSelected?: (frameKey: number) => void;
+    private _nodeMap: Map<number, TopStats> = new Map();
 
     constructor(
         private readonly _extensionUri: vscode.Uri,
@@ -81,15 +83,15 @@ export class CallStackViewProvider implements vscode.WebviewViewProvider {
             if (data.module) {
                 vscode.commands.executeCommand('austin-vscode.openSourceAtLine', data.module, data.line || 0);
             }
-            if (data.pathKey && this._onFrameSelected) {
-                this._onFrameSelected(data.pathKey);
+            if (data.frameKey !== undefined && this._onFrameSelected) {
+                this._onFrameSelected(data.frameKey);
             }
-            if (data.requestChildren) {
-                const node = this._nodeMap.get(data.requestChildren);
+            if (data.requestChildren !== undefined) {
+                const parentFrameKey = data.requestChildren as number;
+                const node = this._nodeMap.get(parentFrameKey);
                 if (node) {
-                    const parentPathKey = data.requestChildren;
-                    const children = [...node.callees.values()].map(child => serializeNode(child, parentPathKey, 3));
-                    this._view?.webview.postMessage({ childrenFor: parentPathKey, children });
+                    const children = [...node.callees.values()].map(child => serializeNode(child, parentFrameKey, 3));
+                    this._view?.webview.postMessage({ childrenFor: parentFrameKey, children });
                 }
             }
         });
@@ -97,7 +99,7 @@ export class CallStackViewProvider implements vscode.WebviewViewProvider {
         webviewView.webview.html = this._getHtml(webviewView.webview);
     }
 
-    public onFrameSelected(cb: (pathKey: string) => void) {
+    public onFrameSelected(cb: (frameKey: number) => void) {
         this._onFrameSelected = cb;
     }
 
@@ -117,8 +119,8 @@ export class CallStackViewProvider implements vscode.WebviewViewProvider {
         this._view?.webview.postMessage({ live: false });
     }
 
-    public focusPath(pathKey: string) {
-        this._view?.webview.postMessage({ focus: { pathKey } });
+    public focusPath(frameKey: number) {
+        this._view?.webview.postMessage({ focus: { frameKey } });
     }
 
     public refresh(stats: AustinStats) {
@@ -126,21 +128,22 @@ export class CallStackViewProvider implements vscode.WebviewViewProvider {
         if (this._view && this._initialized) { this._postData(stats); }
     }
 
-    private _buildNodeMap(node: TopStats, parentPath: string): void {
+    private _buildNodeMap(node: TopStats, parentHash: number): void {
         const scope = normalizeScope(node.scope ?? '');
-        const pathKey = parentPath ? `${parentPath}/${scope}` : scope;
-        this._nodeMap.set(pathKey, node);
+        const key = node.module ? `${node.module}:${scope}` : scope;
+        const frameKey = hashPath(key, parentHash);
+        this._nodeMap.set(frameKey, node);
         for (const child of node.callees.values()) {
-            this._buildNodeMap(child, pathKey);
+            this._buildNodeMap(child, frameKey);
         }
     }
 
     private _postData(stats: AustinStats) {
         this._nodeMap.clear();
         for (const node of stats.callStack.callees.values()) {
-            this._buildNodeMap(node, '');
+            this._buildNodeMap(node, 0);
         }
-        const tree = [...stats.callStack.callees.values()].map(node => serializeNode(node, '', 3));
+        const tree = [...stats.callStack.callees.values()].map(node => serializeNode(node, 0, 3));
         this._view!.webview.postMessage({ tree });
     }
 

--- a/src/providers/flamegraph.ts
+++ b/src/providers/flamegraph.ts
@@ -119,7 +119,7 @@ export class FlameGraphViewProvider implements vscode.WebviewViewProvider {
     private _lines: boolean = false;
     private _stats: AustinStats | null = null;
     private _initialized: boolean = false;
-    private _onFrameSelected?: (pathKey: string) => void;
+    private _onFrameSelected?: (frameKey: number) => void;
     private _sessionActive: boolean = false;
     private _isAttach: boolean = false;
     private _flameHtmlSet: boolean = false;
@@ -221,8 +221,8 @@ export class FlameGraphViewProvider implements vscode.WebviewViewProvider {
             const module = data.file;
             if (source && module) {
                 vscode.commands.executeCommand('austin-vscode.openSourceAtLine', module, data.line || 0);
-                if (this._onFrameSelected && data.pathKey) {
-                    this._onFrameSelected(data.pathKey);
+                if (this._onFrameSelected && data.frameKey !== undefined) {
+                    this._onFrameSelected(data.frameKey);
                 }
             }
         });
@@ -232,7 +232,7 @@ export class FlameGraphViewProvider implements vscode.WebviewViewProvider {
         webviewView.show(true);
     }
 
-    public onFrameSelected(cb: (pathKey: string) => void) {
+    public onFrameSelected(cb: (frameKey: number) => void) {
         this._onFrameSelected = cb;
     }
 
@@ -240,8 +240,8 @@ export class FlameGraphViewProvider implements vscode.WebviewViewProvider {
         this._view?.webview.postMessage({ search: term });
     }
 
-    public focusFrame(pathKey: string) {
-        this._view?.webview.postMessage({ focus: pathKey });
+    public focusFrame(frameKey: number) {
+        this._view?.webview.postMessage({ focus: frameKey });
     }
 
     public focusThread(threadKey: string) {

--- a/src/providers/mcp.ts
+++ b/src/providers/mcp.ts
@@ -1,11 +1,19 @@
 import * as http from 'http';
 import { existsSync } from 'fs';
 import { AustinStats, TopStats } from '../model';
+import { hashPath } from '../utils/pathKey';
 
 export interface McpActions {
     loadFile: (path: string) => void;
-    focusFrame: (pathKey: string) => void;
+    focusFrame: (frameKey: number) => void;
     searchFrames: (term: string) => void;
+}
+
+function normalizeScope(scope: string): string {
+    const match = scope.match(/^([PT])([x0-9A-Fa-f]+)$/);
+    if (!match) { return scope; }
+    const [, type, id] = match;
+    return type === 'P' ? `Process ${id}` : `Thread ${id}`;
 }
 
 const MCP_PROTOCOL_VERSION = '2024-11-05';
@@ -37,7 +45,7 @@ const TOOLS = [
             'Each node has: scope (function name), module (source file path), own (fraction of',
             'total profiling time spent directly in this function body), total (fraction spent in',
             'this function and everything it calls — this is the flame graph width, i.e. the',
-            '"plateau" size), children, and pathKey (pass directly to focus_flamegraph).',
+            '"plateau" size), children, and nodeId (pass directly to focus_flamegraph).',
             '',
             'To find the most interesting plateau in user code:',
             '1. Follow the child with the highest total down from the thread node.',
@@ -119,16 +127,16 @@ const TOOLS = [
     },
     {
         name: 'focus_flamegraph',
-        description: 'Highlights a specific node in the flamegraph by its path key, zooming it into view for the user. The path key is the slash-separated hierarchy built from the call-stack tree returned by get_call_stacks: each node\'s pathKey is formed by joining ancestor scope fields with "/", e.g. "Process 123/Thread 456/outer_func/inner_func". If the exact key is not found, frames whose path contains the key text are still highlighted.',
+        description: 'Zooms the flame graph to a specific node, identified by the nodeId returned in the get_call_stacks response. Call get_call_stacks first to obtain valid node IDs.',
         inputSchema: {
             type: 'object',
             properties: {
-                key: {
-                    type: 'string',
-                    description: 'Path key of the flamegraph node to focus (e.g. "Process 123/Thread 456/my_function").',
+                nodeId: {
+                    type: 'number',
+                    description: 'The nodeId of the flame graph node to focus, as returned by get_call_stacks.',
                 },
             },
-            required: ['key'],
+            required: ['nodeId'],
             additionalProperties: false,
         },
     },
@@ -138,7 +146,7 @@ const TOOLS = [
 // Serialisation helpers
 // ---------------------------------------------------------------------------
 interface CallStackNode {
-    pathKey: string;
+    nodeId: number;
     scope: string | null;
     module: string | null;
     own: number;
@@ -146,15 +154,23 @@ interface CallStackNode {
     children: CallStackNode[];
 }
 
-function serializeCallStackNode(node: TopStats, depth: number, parentKey: string, threshold: number): CallStackNode {
-    const myKey = parentKey ? `${parentKey}/${node.scope ?? ''}` : (node.scope ?? '');
+function serializeCallStackNode(
+    node: TopStats,
+    depth: number,
+    parentHash: number,
+    threshold: number,
+    assignId: (frameKey: number) => number,
+): CallStackNode {
+    const scope = normalizeScope(node.scope ?? '');
+    const key = node.module ? `${node.module}:${scope}` : scope;
+    const myKey = hashPath(key, parentHash);
     const children = depth > 0
         ? [...node.callees.values()]
             .filter(child => child.total * 100 >= threshold)
-            .map(child => serializeCallStackNode(child, depth - 1, myKey, threshold))
+            .map(child => serializeCallStackNode(child, depth - 1, myKey, threshold, assignId))
         : [];
     return {
-        pathKey: myKey,
+        nodeId: assignId(myKey),
         scope: node.scope,
         module: node.module,
         own: parseFloat((node.own * 100).toFixed(2)),
@@ -170,6 +186,8 @@ export class AustinMcpServer {
     private _httpServer: http.Server | null = null;
     private _stats: AustinStats | null = null;
     private _actions: McpActions | null = null;
+    /** Maps nodeId → flamegraph frameKey (hash). Rebuilt on each get_call_stacks call. */
+    private _nodeIdMap: Map<number, number> = new Map();
 
     /** Registers callbacks for UI actions the MCP tools can trigger. */
     setActions(actions: McpActions): void {
@@ -303,7 +321,7 @@ export class AustinMcpServer {
             case 'get_gc_data':
                 return this._getGCData(args.limit as number | undefined);
             case 'focus_flamegraph':
-                return this._focusFlamegraph(args.key as string | undefined);
+                return this._focusFlamegraph(args.nodeId as number | undefined);
             case 'search_flamegraph':
                 return this._searchFlamegraph(args.term as string | undefined);
             default:
@@ -325,15 +343,19 @@ export class AustinMcpServer {
         return [{ type: 'text', text: `Loading profile from ${path}. The flamegraph view will update once parsing is complete.` }];
     }
 
-    private _focusFlamegraph(key?: string): Array<{ type: string; text: string }> {
-        if (!key) {
-            return [{ type: 'text', text: 'Missing required argument: key' }];
+    private _focusFlamegraph(nodeId?: number): Array<{ type: string; text: string }> {
+        if (nodeId === undefined) {
+            return [{ type: 'text', text: 'Missing required argument: nodeId' }];
+        }
+        const frameKey = this._nodeIdMap.get(nodeId);
+        if (frameKey === undefined) {
+            return [{ type: 'text', text: 'Unknown nodeId. Call get_call_stacks first to obtain valid node IDs.' }];
         }
         if (!this._actions) {
             return [{ type: 'text', text: 'Flamegraph focus is not available.' }];
         }
-        this._actions.focusFrame(key);
-        return [{ type: 'text', text: `Focused flamegraph node: ${key}` }];
+        this._actions.focusFrame(frameKey);
+        return [{ type: 'text', text: `Focused flamegraph node ${nodeId}.` }];
     }
 
     private _searchFlamegraph(term?: string): Array<{ type: string; text: string }> {
@@ -367,9 +389,16 @@ export class AustinMcpServer {
 
     private _getCallStacks(depth: number = 15, threshold: number = 0): Array<{ type: string; text: string }> {
         const stats = this._stats!;
+        this._nodeIdMap.clear();
+        let nextId = 0;
+        const assignId = (frameKey: number) => {
+            const id = nextId++;
+            this._nodeIdMap.set(id, frameKey);
+            return id;
+        };
         const tree = [...stats.callStack.callees.values()]
             .filter(n => n.total * 100 >= threshold)
-            .map(n => serializeCallStackNode(n, depth - 1, '', threshold));
+            .map(n => serializeCallStackNode(n, depth - 1, 0, threshold, assignId));
         return [{ type: 'text', text: JSON.stringify(tree, null, 2) }];
     }
 

--- a/src/test/suite/mcp.test.ts
+++ b/src/test/suite/mcp.test.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs';
 import * as http from 'http';
 import * as os from 'os';
 import * as path from 'path';
+import { hashPath } from '../../utils/pathKey';
 import { Readable } from 'stream';
 import { AustinMcpServer } from '../../providers/mcp';
 import { AustinStats } from '../../model';
@@ -396,9 +397,9 @@ suite('AustinMcpServer', () => {
         assert.strictEqual(frames.length, 1);
     });
 
-    // --- get_call_stacks pathKey --------------------------------------------
+    // --- get_call_stacks nodeId ---------------------------------------------
 
-    test('get_call_stacks nodes include pathKey', async () => {
+    test('get_call_stacks nodes include a unique numeric nodeId', async () => {
         const stats = await makeStats('P1;T1;/a.py:fn:1 100\n');
         server = await startedServer(stats);
         const res = await post(server.port, {
@@ -407,30 +408,45 @@ suite('AustinMcpServer', () => {
         }) as Record<string, unknown>;
 
         const content = (res.result as Record<string, unknown>).content as Array<{ type: string; text: string }>;
-        type Node = { pathKey: string; children: Node[] };
+        type Node = { nodeId: number; children: Node[] };
         const tree = JSON.parse(content[0].text) as Node[];
         const processNode = tree[0];
-        assert.strictEqual(processNode.pathKey, 'Process 1');
         const threadNode = processNode.children[0];
-        assert.ok(threadNode.pathKey.startsWith('Process 1/Thread '), 'thread pathKey should be nested under process');
         const frameNode = threadNode.children[0];
-        assert.strictEqual(frameNode.pathKey, threadNode.pathKey + '/fn');
+        assert.strictEqual(typeof processNode.nodeId, 'number');
+        assert.strictEqual(typeof threadNode.nodeId, 'number');
+        assert.strictEqual(typeof frameNode.nodeId, 'number');
+        const ids = new Set([processNode.nodeId, threadNode.nodeId, frameNode.nodeId]);
+        assert.strictEqual(ids.size, 3, 'nodeIds should be unique');
     });
 
-    test('get_call_stacks pathKey is consistent across nested children', async () => {
-        const stats = await makeStats('P1;T1;/a.py:outer:1;/a.py:inner:2 100\n');
+    test('get_call_stacks nodeId resolves to the correct flamegraph path via focus_flamegraph', async () => {
+        const stats = await makeStats('P1;T1;/a.py:fn:1 100\n');
         server = await startedServer(stats);
-        const res = await post(server.port, {
+
+        const csRes = await post(server.port, {
             jsonrpc: '2.0', method: 'tools/call', id: 20,
             params: { name: 'get_call_stacks', arguments: {} },
         }) as Record<string, unknown>;
+        const csContent = (csRes.result as Record<string, unknown>).content as Array<{ type: string; text: string }>;
+        type Node = { nodeId: number; scope: string; children: Node[] };
+        const tree = JSON.parse(csContent[0].text) as Node[];
+        const frameNode = tree[0].children[0].children[0]; // process → thread → frame
+        assert.strictEqual(frameNode.scope, 'fn');
 
-        const content = (res.result as Record<string, unknown>).content as Array<{ type: string; text: string }>;
-        type Node = { pathKey: string; children: Node[] };
-        const tree = JSON.parse(content[0].text) as Node[];
-        const frameNode = tree[0].children[0].children[0];
-        const nestedNode = frameNode.children[0];
-        assert.ok(nestedNode.pathKey.startsWith(frameNode.pathKey + '/'), 'nested pathKey should extend parent');
+        let calledWith: number | null = null;
+        server.setActions({ loadFile: () => {}, focusFrame: (k) => { calledWith = k; }, searchFrames: () => {} });
+        await post(server.port, {
+            jsonrpc: '2.0', method: 'tools/call', id: 20,
+            params: { name: 'focus_flamegraph', arguments: { nodeId: frameNode.nodeId } },
+        });
+        // Verify the exact frameKey: rolling hash matching flamegraph.js for P1→T1→/a.py:fn.
+        // The parser strips the leading "P"/"T" from pid/tid, so pid="1" → "Process 1",
+        // tid="1" → "Thread 1". Process/thread nodes have no module so their key is the
+        // bare scope; frames use "module:scope" (matching node.key in the flamegraph hierarchy).
+        const expectedKey = hashPath('/a.py:fn', hashPath('Thread 1', hashPath('Process 1')));
+        assert.strictEqual(calledWith, expectedKey,
+            `focusFrame should receive frameKey=${expectedKey} (Process 1 → Thread 1 → /a.py:fn), got: ${calledWith}`);
     });
 
     // --- load_profile -------------------------------------------------------
@@ -518,13 +534,13 @@ suite('AustinMcpServer', () => {
         server.setActions({ loadFile: () => {}, focusFrame: () => {}, searchFrames: () => {} });
         const res = await post(server.port, {
             jsonrpc: '2.0', method: 'tools/call', id: 26,
-            params: { name: 'focus_flamegraph', arguments: { key: 'Process 1/Thread T1/fn' } },
+            params: { name: 'focus_flamegraph', arguments: { nodeId: 0 } },
         }) as Record<string, unknown>;
         const content = (res.result as Record<string, unknown>).content as Array<{ type: string; text: string }>;
         assert.ok(content[0].text.includes('No profiling data'));
     });
 
-    test('focus_flamegraph returns error for missing key argument', async () => {
+    test('focus_flamegraph returns error for missing nodeId argument', async () => {
         const stats = await makeStats('P1;T1;/a.py:fn:1 100\n');
         server = await startedServer(stats);
         server.setActions({ loadFile: () => {}, focusFrame: () => {}, searchFrames: () => {} });
@@ -536,26 +552,34 @@ suite('AustinMcpServer', () => {
         assert.ok(content[0].text.toLowerCase().includes('missing'));
     });
 
-    test('focus_flamegraph invokes focusFrame action with the given key', async () => {
+    test('focus_flamegraph returns error for unknown nodeId', async () => {
         const stats = await makeStats('P1;T1;/a.py:fn:1 100\n');
         server = await startedServer(stats);
-        let calledWith: string | null = null;
-        server.setActions({ loadFile: () => {}, focusFrame: (k) => { calledWith = k; }, searchFrames: () => {} });
-        const key = 'Process 1/Thread T1/fn';
-        await post(server.port, {
+        server.setActions({ loadFile: () => {}, focusFrame: () => {}, searchFrames: () => {} });
+        // 9999 was never returned by get_call_stacks
+        const res = await post(server.port, {
             jsonrpc: '2.0', method: 'tools/call', id: 28,
-            params: { name: 'focus_flamegraph', arguments: { key } },
-        });
-        assert.strictEqual(calledWith, key);
+            params: { name: 'focus_flamegraph', arguments: { nodeId: 9999 } },
+        }) as Record<string, unknown>;
+        const content = (res.result as Record<string, unknown>).content as Array<{ type: string; text: string }>;
+        assert.ok(content[0].text.toLowerCase().includes('unknown'));
     });
 
     test('focus_flamegraph returns not-available message when no actions are set', async () => {
         const stats = await makeStats('P1;T1;/a.py:fn:1 100\n');
         server = await startedServer(stats);
-        // Deliberately do not call setActions
+        // Populate _nodeIdMap via get_call_stacks, then attempt focus without actions
+        const csRes = await post(server.port, {
+            jsonrpc: '2.0', method: 'tools/call', id: 29,
+            params: { name: 'get_call_stacks', arguments: {} },
+        }) as Record<string, unknown>;
+        const csContent = (csRes.result as Record<string, unknown>).content as Array<{ type: string; text: string }>;
+        type Node = { nodeId: number; children: Node[] };
+        const nodeId = (JSON.parse(csContent[0].text) as Node[])[0].nodeId;
+
         const res = await post(server.port, {
             jsonrpc: '2.0', method: 'tools/call', id: 29,
-            params: { name: 'focus_flamegraph', arguments: { key: 'Process 1/Thread T1/fn' } },
+            params: { name: 'focus_flamegraph', arguments: { nodeId } },
         }) as Record<string, unknown>;
         const content = (res.result as Record<string, unknown>).content as Array<{ type: string; text: string }>;
         assert.ok(content[0].text.toLowerCase().includes('not available'));

--- a/src/test/suite/pathKey.test.ts
+++ b/src/test/suite/pathKey.test.ts
@@ -1,0 +1,57 @@
+import * as assert from 'assert';
+import { hashPath } from '../../utils/pathKey';
+
+suite('hashPath', () => {
+
+    test('returns a 32-bit unsigned integer', () => {
+        const h = hashPath('hello');
+        assert.strictEqual(typeof h, 'number');
+        assert.ok(Number.isInteger(h) && h >= 0 && h <= 0xFFFF_FFFF,
+            `${h} should be an integer in [0, 2^32)`);
+    });
+
+    test('no-seed call is equivalent to seed=0', () => {
+        assert.strictEqual(hashPath('foo'), hashPath('foo', 0));
+        assert.strictEqual(hashPath('Process 1'), hashPath('Process 1', 0));
+    });
+
+    test('is deterministic', () => {
+        assert.strictEqual(hashPath('foo', 42), hashPath('foo', 42));
+    });
+
+    test('different names produce different hashes', () => {
+        assert.notStrictEqual(hashPath('fn'), hashPath('other'));
+        assert.notStrictEqual(hashPath('Process 1'), hashPath('Thread 1'));
+    });
+
+    test('rolling hash is order-sensitive (A→B ≠ B→A)', () => {
+        const ab = hashPath('B', hashPath('A'));
+        const ba = hashPath('A', hashPath('B'));
+        assert.notStrictEqual(ab, ba);
+    });
+
+    test('rolling hash is depth-sensitive (same leaf under different parents)', () => {
+        const aFn = hashPath('fn', hashPath('A'));
+        const bFn = hashPath('fn', hashPath('B'));
+        assert.notStrictEqual(aFn, bFn);
+    });
+
+    test('rolling chain matches the path used by the extension and the webview', () => {
+        // Simulate the path built for Process 1 → Thread 1 → /a.py:fn.
+        // Both callstack.ts (extension host) and flamegraph.js (webview) compute
+        // frameKey the same way because they share this function.
+        // Process/thread nodes have no module, so their key is the bare scope name.
+        // Frame nodes use "module:scope" as their key (matching node.key in the hierarchy).
+        const processKey = hashPath('Process 1');
+        const threadKey  = hashPath('Thread 1', processKey);
+        const fnKey      = hashPath('/a.py:fn', threadKey);
+
+        // All three keys must be distinct
+        const keys = new Set([processKey, threadKey, fnKey]);
+        assert.strictEqual(keys.size, 3, 'process, thread, and frame keys must all differ');
+
+        // Each level must differ from a flat (unseeded) hash of the same name
+        assert.notStrictEqual(threadKey, hashPath('Thread 1'));
+        assert.notStrictEqual(fnKey,     hashPath('/a.py:fn'));
+    });
+});

--- a/src/utils/pathKey.ts
+++ b/src/utils/pathKey.ts
@@ -1,0 +1,8 @@
+// The canonical hashPath implementation lives in media/flamegraph-utils.js, which is
+// the UMD module loaded by the flamegraph webview. Re-exporting it here means the
+// extension host and the webview always use the same function — no duplication to
+// keep in sync. The path resolves identically from both src/utils/ and out/utils/.
+const { hashPath } = require('../../media/flamegraph-utils.js') as {
+    hashPath: (text: string, seed?: number) => number;
+};
+export { hashPath };


### PR DESCRIPTION
Replace slash-joined path strings with compact 32-bit integer hashes throughout the flamegraph↔callstack sync and MCP layer. Each node hashes only its own key seeded from its parent's hash, keeping memory and key comparison O(1) regardless of call-stack depth.

- Add hashPath(text, seed?) in media/flamegraph-utils.js as the single canonical implementation (UMD module shared by both the webview and the extension host via re-export in src/utils/pathKey.ts)
- flamegraph.js: addPathKeys uses node.key (module:scope for frames, bare name for process/thread) to avoid hash collisions between same-named functions in different modules; focusByKey/applySearch compare by frameKey number
- callstack.ts / mcp.ts: serializeNode and _buildNodeMap compute key = module ? `${module}:${scope}` : scope, matching the flamegraph hierarchy; _nodeMap is now Map<number, TopStats> (no _frameKeyMap)
- extension.ts: wires onFrameSelected/focusFrame/focusPath using number
- Add src/test/suite/pathKey.test.ts covering rolling hash properties
- Update mcp.test.ts focus_flamegraph assertion to use exact hash chain