### PR TITLE
chore: improve native frames visuals

### DIFF
--- a/media/callstack.js
+++ b/media/callstack.js
@@ -94,6 +94,7 @@
         const hasChildren = (node.children && node.children.length > 0) || node.childrenPending;
 
         const tr = document.createElement('tr');
+        if (isNative(node.module)) { tr.classList.add('native-frame'); }
         tr.dataset.rowId = rowId;
         tr.dataset.level = String(level);
         if (parentId !== null) {
@@ -217,6 +218,7 @@
         const hasChildren = (node.children && node.children.length > 0) || node.childrenPending;
 
         const tr = document.createElement('tr');
+        if (isNative(node.module)) { tr.classList.add('native-frame'); }
         tr.dataset.rowId = rowId;
         tr.dataset.level = String(level);
         tr.dataset.parentId = parentId;
@@ -266,6 +268,10 @@
         if (pct >= 50) { return '#e67e22'; }
         if (pct >= 25) { return '#f1c40f'; }
         return null;
+    }
+
+    function isNative(module) {
+        return !!module && !module.endsWith('.py') && !(module.startsWith('<') && module.endsWith('>'));
     }
 
     function fmt(v) { return (v * 100).toFixed(2); }

--- a/media/flamegraph-utils.js
+++ b/media/flamegraph-utils.js
@@ -58,7 +58,8 @@
         if (!node.file) { return hslToHex(0, 10, 70); }
         const h = hash(node.file) % 360;
         const s = hash(node.name || '') % 10;
-        return hslToHex(h >= 0 ? h : -h, (node.file.endsWith('.py') ? 60 : 20) + s, 60);
+        const isPy = node.file.endsWith('.py') || (node.file.startsWith('<') && node.file.endsWith('>'));
+        return hslToHex(h >= 0 ? h : -h, (isPy ? 60 : 5) + s, isPy ? 60 : 45);
     }
 
     /** @param {string} text */

--- a/media/flamegraph.js
+++ b/media/flamegraph.js
@@ -140,6 +140,24 @@
             ctx.fillStyle = f.color;
             ctx.fillRect(x, y, w, CELL_H);
 
+            // Native (non-Python) frames get a diagonal hatch overlay
+            if (f.node.file && !f.node.file.endsWith('.py')) {
+                ctx.save();
+                ctx.beginPath();
+                ctx.rect(x, y, w, CELL_H);
+                ctx.clip();
+                ctx.strokeStyle = 'rgba(0,0,0,0.22)';
+                ctx.lineWidth = 1.5;
+                const step = 5;
+                for (let ox = -CELL_H; ox < w + CELL_H; ox += step) {
+                    ctx.beginPath();
+                    ctx.moveTo(x + ox, y);
+                    ctx.lineTo(x + ox + CELL_H, y + CELL_H);
+                    ctx.stroke();
+                }
+                ctx.restore();
+            }
+
             ctx.strokeStyle = 'rgba(0,0,0,0.18)';
             ctx.lineWidth = 0.5;
             ctx.strokeRect(x + 0.25, y + 0.25, w - 0.5, CELL_H - 0.5);

--- a/media/gctop.js
+++ b/media/gctop.js
@@ -111,6 +111,7 @@
         for (const item of filtered) {
             const tr = document.createElement('tr');
             tr.className = 'frame-row';
+            if (isNative(item.module)) { tr.classList.add('native-frame'); }
             if (item.module) { tr.title = item.module; }
             tr.innerHTML =
                 gcCell(item.gcOwn) +
@@ -140,6 +141,10 @@
             `<span class="scope-name">${esc(scope || '')}</span>` +
             (mod ? `<span class="scope-module">${esc(mod)}</span>` : '') +
             `</td>`;
+    }
+
+    function isNative(module) {
+        return !!module && !module.endsWith('.py') && !(module.startsWith('<') && module.endsWith('>'));
     }
 
     function statColor(value) {

--- a/media/top.js
+++ b/media/top.js
@@ -113,6 +113,7 @@
 
         const tr = document.createElement('tr');
         tr.className = 'top-row';
+        if (isNative(item.module)) { tr.classList.add('native-frame'); }
         tr.dataset.rowId = rowId;
         tr.dataset.level = '0';
         tr.dataset.callerKey = item.key;
@@ -145,6 +146,7 @@
 
             const tr = document.createElement('tr');
             tr.className = 'caller-row';
+            if (isNative(caller.module)) { tr.classList.add('native-frame'); }
             tr.dataset.rowId = rowId;
             tr.dataset.parentId = parentId;
             tr.dataset.level = String(level);
@@ -335,6 +337,10 @@
         if (pct >= 50) { return '#e67e22'; }
         if (pct >= 25) { return '#f1c40f'; }
         return null;
+    }
+
+    function isNative(module) {
+        return !!module && !module.endsWith('.py') && !(module.startsWith('<') && module.endsWith('>'));
     }
 
     function fmt(v) { return (v * 100).toFixed(2); }

--- a/media/views.css
+++ b/media/views.css
@@ -1,0 +1,54 @@
+/* Shared styles for the austin-vscode panel views (top, callstack, gctop). */
+
+* { box-sizing: border-box; }
+
+body {
+    padding: 0;
+    margin: 0;
+    font-size: var(--vscode-font-size, 12px);
+    font-family: var(--vscode-font-family, sans-serif);
+    color: var(--vscode-foreground);
+    background: transparent;
+}
+
+th.desc::after { content: " ▼"; font-size: 9px; }
+th.asc::after  { content: " ▲"; font-size: 9px; }
+
+.func { font-family: var(--vscode-editor-font-family, monospace); font-size: var(--vscode-editor-font-size, 1em); }
+
+.scope-name {
+    font-family: var(--vscode-editor-font-family, monospace);
+    font-size: var(--vscode-editor-font-size, 1em);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.scope-module {
+    margin-left: 6px;
+    font-size: 0.85em;
+    color: var(--vscode-descriptionForeground);
+    white-space: nowrap;
+}
+
+tr.native-frame .scope-name,
+tr.native-frame .scope-module { opacity: 0.55; }
+
+.bar-row { display: flex; align-items: center; gap: 4px; }
+.bar-bg {
+    flex: 0 0 24px;
+    height: 5px;
+    background: var(--vscode-progressBar-background, rgba(128,128,128,0.2));
+    border-radius: 3px;
+    overflow: hidden;
+}
+.bar-fill { height: 5px; border-radius: 3px; background: var(--vscode-descriptionForeground); opacity: 0.4; }
+.bar-fill[style] { opacity: 1; }
+.pct {
+    width: 40px;
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+    font-family: var(--vscode-editor-font-family, monospace);
+    flex-shrink: 0;
+    font-size: var(--vscode-editor-font-size, 1em);
+}

--- a/src/flamegraph-svg.ts
+++ b/src/flamegraph-svg.ts
@@ -33,7 +33,8 @@ function colorFor(node: any): string {
     if (!node.file) { return hslToHex(0, 10, 70); }
     const h = nodeHash(node.file) % 360;
     const s = nodeHash(node.name || '') % 10;
-    return hslToHex(h >= 0 ? h : -h, (node.file.endsWith('.py') ? 60 : 20) + s, 60);
+    const isPy = node.file.endsWith('.py') || (node.file.startsWith('<') && node.file.endsWith('>'));
+    return hslToHex(h >= 0 ? h : -h, (isPy ? 60 : 5) + s, isPy ? 60 : 45);
 }
 
 function nodeBasename(p: string): string {
@@ -164,12 +165,18 @@ export function generateInteractiveSVG(hierarchy: any, mode: string, logoB64?: s
             (file ? ` <tspan opacity="0.5">${escXml(file)}</tspan>` : '');
         const textHide = f.w < LABEL_MIN_W ? ' display="none"' : '';
 
+        const isNative = f.node.file && !f.node.file.endsWith('.py');
         frameEls.push(
             `<g class="frame" id="f${id}" data-id="${id}" style="cursor:pointer">` +
             `<rect id="r${id}" x="${f.x.toFixed(1)}" y="${fy}" ` +
             `width="${f.w.toFixed(1)}" height="${CELL_H}" ` +
             `fill="${f.color}" opacity="${opacity}" ` +
             `stroke="rgba(0,0,0,0.18)" stroke-width="0.5"/>` +
+            (isNative
+                ? `<rect id="nh${id}" x="${f.x.toFixed(1)}" y="${fy}" ` +
+                  `width="${f.w.toFixed(1)}" height="${CELL_H}" ` +
+                  `fill="url(#native-hatch)" opacity="${opacity}" pointer-events="none"/>`
+                : '') +
             `<text id="t${id}" clip-path="url(#c${id})" ` +
             `x="${(f.x + 4).toFixed(1)}" y="${(fy + CELL_H / 2).toFixed(1)}" ` +
             `dominant-baseline="middle" font-size="13" ` +
@@ -188,6 +195,8 @@ export function generateInteractiveSVG(hierarchy: any, mode: string, logoB64?: s
         `     style="background:${bgColor};font-family:system-ui,sans-serif;display:block">`,
         ``,
         `  <defs>`,
+        `    <pattern id="native-hatch" patternUnits="userSpaceOnUse" width="6" height="6">` +
+        `<path d="M-1,1 l2,-2 M0,6 l6,-6 M5,7 l2,-2" stroke="rgba(0,0,0,0.2)" stroke-width="1.5" stroke-linecap="square"/></pattern>`,
         ...clipDefs.map(d => `    ${d}`),
         `  </defs>`,
         ``,
@@ -266,7 +275,8 @@ function buildEmbeddedScript(): string {
         if (n.kind === 'thread')  { return hslToHex(240, nhash(n.name) % 20, 70); }
         if (!n.file) { return hslToHex(0, 10, 70); }
         const h = nhash(n.file) % 360;
-        return hslToHex(h >= 0 ? h : -h, (n.file.endsWith('.py') ? 60 : 20) + nhash(n.name || '') % 10, 60);
+        const ip = n.file.endsWith('.py') || (n.file.startsWith('<') && n.file.endsWith('>'));
+        return hslToHex(h >= 0 ? h : -h, (ip ? 60 : 5) + nhash(n.name || '') % 10, ip ? 60 : 45);
     }
     function basename(p) { return p ? p.replace(/\\/g, '/').split('/').pop() || p : ''; }
     function fmt(v) {
@@ -369,6 +379,13 @@ function buildEmbeddedScript(): string {
                 rect.setAttribute('width',   f.w);
                 rect.setAttribute('opacity', op);
                 rect.setAttribute('fill',    colorFor(f.node));
+            }
+            const hatch = document.getElementById('nh' + id);
+            if (hatch) {
+                hatch.setAttribute('x',       f.x);
+                hatch.setAttribute('y',       fy);
+                hatch.setAttribute('width',   f.w);
+                hatch.setAttribute('opacity', op);
             }
             if (cr) {
                 cr.setAttribute('x',     f.x);

--- a/src/providers/callstack.ts
+++ b/src/providers/callstack.ts
@@ -154,6 +154,9 @@ export class CallStackViewProvider implements vscode.WebviewViewProvider {
         const codiconsUri = webview.asWebviewUri(
             vscode.Uri.joinPath(this._extensionUri, 'media', 'codicons', 'codicon.css')
         );
+        const viewsCssUri = webview.asWebviewUri(
+            vscode.Uri.joinPath(this._extensionUri, 'media', 'views.css')
+        );
 
         return `<!DOCTYPE html>
 <html lang="en">
@@ -161,16 +164,8 @@ export class CallStackViewProvider implements vscode.WebviewViewProvider {
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" type="text/css" href="${codiconsUri}">
+    <link rel="stylesheet" type="text/css" href="${viewsCssUri}">
     <style>
-        * { box-sizing: border-box; }
-        body {
-            padding: 0;
-            margin: 0;
-            font-size: var(--vscode-font-size, 12px);
-            font-family: var(--vscode-font-family, sans-serif);
-            color: var(--vscode-foreground);
-            background: transparent;
-        }
         .toolbar {
             display: flex;
             align-items: center;
@@ -238,8 +233,6 @@ export class CallStackViewProvider implements vscode.WebviewViewProvider {
         th.scope-header { text-align: left; }
         th.stat-header  { text-align: right; width: 64px; cursor: pointer; user-select: none; }
         th.stat-header:hover { background: var(--vscode-list-hoverBackground); }
-        th.desc::after { content: " ▼"; font-size: 9px; }
-        th.asc::after  { content: " ▲"; font-size: 9px; }
         td {
             padding: 2px 6px;
             border-bottom: 1px solid var(--vscode-list-inactiveSelectionBackground, rgba(128,128,128,0.1));
@@ -266,15 +259,6 @@ export class CallStackViewProvider implements vscode.WebviewViewProvider {
         }
         tr[data-open] .chevron { transform: rotate(90deg); }
         tr:not([data-expandable]) .chevron { visibility: hidden; }
-        .scope-name {
-            font-family: var(--vscode-editor-font-family, monospace);
-            font-size: var(--vscode-editor-font-size, 1em);
-        }
-        .scope-module {
-            margin-left: 6px;
-            font-size: 0.85em;
-            color: var(--vscode-descriptionForeground);
-        }
         /* stat cells */
         td.stat {
             text-align: right;

--- a/src/providers/gctop.ts
+++ b/src/providers/gctop.ts
@@ -185,6 +185,9 @@ export class GCTopViewProvider implements vscode.WebviewViewProvider {
         const codiconsUri = webview.asWebviewUri(
             vscode.Uri.joinPath(this._extensionUri, 'node_modules', '@vscode/codicons', 'dist', 'codicon.css')
         );
+        const viewsCssUri = webview.asWebviewUri(
+            vscode.Uri.joinPath(this._extensionUri, 'media', 'views.css')
+        );
 
         return `<!DOCTYPE html>
 <html lang="en">
@@ -192,17 +195,9 @@ export class GCTopViewProvider implements vscode.WebviewViewProvider {
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" type="text/css" href="${codiconsUri}">
+    <link rel="stylesheet" type="text/css" href="${viewsCssUri}">
     <style>
-        * { box-sizing: border-box; }
-        body {
-            padding: 0;
-            margin: 0;
-            font-size: var(--vscode-font-size, 12px);
-            font-family: var(--vscode-font-family, sans-serif);
-            color: var(--vscode-foreground);
-            background: transparent;
-            overflow-x: hidden;
-        }
+        body { overflow-x: hidden; }
         table {
             width: 100%;
             border-collapse: collapse;
@@ -224,8 +219,6 @@ export class GCTopViewProvider implements vscode.WebviewViewProvider {
         }
         th[data-col] { cursor: pointer; user-select: none; }
         th[data-col]:hover { background: var(--vscode-list-hoverBackground); }
-        th.desc::after { content: " ▼"; font-size: 9px; }
-        th.asc::after  { content: " ▲"; font-size: 9px; }
         td {
             padding: 3px 4px;
             border-bottom: 1px solid var(--vscode-list-inactiveSelectionBackground, rgba(128,128,128,0.1));
@@ -237,37 +230,6 @@ export class GCTopViewProvider implements vscode.WebviewViewProvider {
         .frame-row > td { cursor: pointer; }
         .frame-row:hover > td { background: var(--vscode-list-hoverBackground); }
         col.func { width: 100%; }
-        .bar-row { display: flex; align-items: center; gap: 4px; }
-        .bar-bg {
-            flex: 0 0 24px;
-            height: 5px;
-            background: var(--vscode-progressBar-background, rgba(128,128,128,0.2));
-            border-radius: 3px;
-            overflow: hidden;
-        }
-        .bar-fill { height: 5px; border-radius: 3px; background: var(--vscode-descriptionForeground); opacity: 0.4; }
-        .bar-fill[style] { opacity: 1; }
-        .pct {
-            width: 40px;
-            text-align: right;
-            font-variant-numeric: tabular-nums;
-            font-family: var(--vscode-editor-font-family, monospace);
-            flex-shrink: 0;
-            font-size: var(--vscode-editor-font-size, 1em);
-        }
-        .func { font-family: var(--vscode-editor-font-family, monospace); font-size: var(--vscode-editor-font-size, 1em); }
-        .scope-name {
-            font-family: var(--vscode-editor-font-family, monospace);
-            font-size: var(--vscode-editor-font-size, 1em);
-            overflow: hidden;
-            text-overflow: ellipsis;
-            white-space: nowrap;
-        }
-        .scope-module {
-            margin-left: 6px;
-            font-size: 0.85em;
-            color: var(--vscode-descriptionForeground);
-        }
         /* Thread summary section */
         #thread-summary {
             padding: 6px 8px 4px 8px;

--- a/src/providers/top.ts
+++ b/src/providers/top.ts
@@ -163,6 +163,9 @@ export class TopViewProvider implements vscode.WebviewViewProvider {
         const codiconsUri = webview.asWebviewUri(
             vscode.Uri.joinPath(this._extensionUri, 'media', 'codicons', 'codicon.css')
         );
+        const viewsCssUri = webview.asWebviewUri(
+            vscode.Uri.joinPath(this._extensionUri, 'media', 'views.css')
+        );
 
         return `<!DOCTYPE html>
 <html lang="en">
@@ -170,17 +173,9 @@ export class TopViewProvider implements vscode.WebviewViewProvider {
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" type="text/css" href="${codiconsUri}">
+    <link rel="stylesheet" type="text/css" href="${viewsCssUri}">
     <style>
-        * { box-sizing: border-box; }
-        body {
-            padding: 0;
-            margin: 0;
-            font-size: var(--vscode-font-size, 12px);
-            font-family: var(--vscode-font-family, sans-serif);
-            color: var(--vscode-foreground);
-            background: transparent;
-            overflow-x: hidden;
-        }
+        body { overflow-x: hidden; }
         table {
             width: 100%;
             border-collapse: collapse;
@@ -208,8 +203,6 @@ export class TopViewProvider implements vscode.WebviewViewProvider {
             user-select: none;
         }
         th[data-col]:hover { background: var(--vscode-list-hoverBackground); }
-        th.desc::after { content: " ▼"; font-size: 9px; }
-        th.asc::after  { content: " ▲"; font-size: 9px; }
         td {
             padding: 3px 4px;
             border-bottom: 1px solid var(--vscode-list-inactiveSelectionBackground, rgba(128,128,128,0.1));
@@ -230,38 +223,6 @@ export class TopViewProvider implements vscode.WebviewViewProvider {
             padding-bottom: 7px;
         }
         col.func  { width: 100%; }
-        .bar-row { display: flex; align-items: center; gap: 4px; }
-        .bar-bg {
-            flex: 0 0 24px;
-            height: 5px;
-            background: var(--vscode-progressBar-background, rgba(128,128,128,0.2));
-            border-radius: 3px;
-            overflow: hidden;
-        }
-        .bar-fill { height: 5px; border-radius: 3px; background: var(--vscode-descriptionForeground); opacity: 0.4; }
-        .bar-fill[style] { opacity: 1; }
-        .pct {
-            width: 40px;
-            text-align: right;
-            font-variant-numeric: tabular-nums;
-            font-family: var(--vscode-editor-font-family, monospace);
-            flex-shrink: 0;
-            font-size: var(--vscode-editor-font-size, 1em);
-        }
-        .func { font-family: var(--vscode-editor-font-family, monospace); font-size: var(--vscode-editor-font-size, 1em); }
-        .scope-name {
-            font-family: var(--vscode-editor-font-family, monospace);
-            font-size: var(--vscode-editor-font-size, 1em);
-            overflow: hidden;
-            text-overflow: ellipsis;
-            white-space: nowrap;
-        }
-        .scope-module {
-            margin-left: 6px;
-            font-size: 0.85em;
-            color: var(--vscode-descriptionForeground);
-            white-space: nowrap;
-        }
         .caller-row > td {
             font-size: 0.9em;
             border-bottom-color: transparent;


### PR DESCRIPTION
We improve the way native frames are visualised in flame graphs and other webviews.

<img width="1598" height="1011" alt="Screenshot 2026-04-10 at 15 24 46" src="https://github.com/user-attachments/assets/c2b6f2ea-ba72-48a4-ba6e-dca3f993a26d" />
