### PR TITLE
perf: cap top view entries

### DIFF
--- a/media/top.css
+++ b/media/top.css
@@ -64,3 +64,18 @@ col.func { width: 100%; }
 .caller-row .pct  { font-size: 0.85em; width: 36px; }
 
 .toolbar-btn { flex-shrink: 0; }
+
+.truncated {
+    padding: 8px 10px;
+    font-size: 0.85em;
+    color: var(--vscode-descriptionForeground, rgba(204,204,204,0.7));
+    text-align: center;
+}
+.truncated a {
+    color: var(--vscode-textLink-foreground, #3794ff);
+    text-decoration: none;
+    cursor: pointer;
+}
+.truncated a:hover {
+    text-decoration: underline;
+}

--- a/media/top.html
+++ b/media/top.html
@@ -50,6 +50,7 @@
         </thead>
         <tbody id="tbody"></tbody>
     </table>
+    <div id="truncated" class="truncated" style="display:none"></div>
     <script src="{{scriptUri}}"></script>
 </body>
 </html>

--- a/media/top.js
+++ b/media/top.js
@@ -2,6 +2,7 @@
     const vscode = acquireVsCodeApi();
 
     let data = [];
+    let totalCount = 0;
     let sortCol = 'own';
     let sortAsc = false;
     let filterTerm = '';
@@ -33,6 +34,7 @@
         } else if (message.top !== undefined) {
             loading.classList.remove('active');
             data = message.top;
+            totalCount = message.totalCount || data.length;
             const emptyEl = document.getElementById('empty');
             emptyEl.textContent = 'No profiling data loaded.';
             emptyEl.style.color = '';
@@ -92,6 +94,21 @@
         }
 
         restoreExpanded();
+
+        const truncatedEl = document.getElementById('truncated');
+        const dropped = totalCount - data.length;
+        if (dropped > 0) {
+            truncatedEl.innerHTML =
+                `Showing ${data.length} of ${totalCount} rows (${dropped} hidden). ` +
+                `<a href="#" id="open-settings-link">Change limit in settings</a>`;
+            truncatedEl.style.display = '';
+            document.getElementById('open-settings-link').addEventListener('click', e => {
+                e.preventDefault();
+                vscode.postMessage('openSettings');
+            });
+        } else {
+            truncatedEl.style.display = 'none';
+        }
     }
 
     function restoreExpanded() {

--- a/package.json
+++ b/package.json
@@ -82,6 +82,12 @@
             "Both percent and absolute metric values"
           ],
           "default": "Percent"
+        },
+        "austin.topRows": {
+          "description": "Maximum number of rows to display in the Top view. Set to 0 for unlimited.",
+          "type": "number",
+          "default": 50,
+          "minimum": 0
         }
       }
     },

--- a/src/providers/top.ts
+++ b/src/providers/top.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { AustinStats, TopStats } from '../model';
+import { AustinRuntimeSettings } from '../settings';
 import { loadWebviewHtml } from '../utils/webviewHtml';
 
 interface CallerNode {
@@ -63,6 +64,10 @@ export class TopViewProvider implements vscode.WebviewViewProvider {
             }
             if (data === 'attach') {
                 vscode.commands.executeCommand('austin-vscode.attach');
+                return;
+            }
+            if (data === 'openSettings') {
+                vscode.commands.executeCommand('workbench.action.openSettings', 'austin.topRows');
                 return;
             }
             if (data.module !== undefined) {
@@ -140,21 +145,24 @@ export class TopViewProvider implements vscode.WebviewViewProvider {
     }
 
     private _postData(stats: AustinStats) {
-        const top: TopItemData[] = [...stats.top.values()]
-            .sort((a, b) => b.own - a.own)
-            .map(s => {
-                const key = s.key();
-                return {
-                    key,
-                    scope: s.scope,
-                    module: s.module,
-                    own: s.own,
-                    total: s.total,
-                    line: s.minLine,
-                    callers: this._serializeCallers(s, new Set([key]), 3),
-                };
-            });
-        this._view!.webview.postMessage({ top });
+        const limit = AustinRuntimeSettings.getTopRows();
+        const sorted = [...stats.top.values()].sort((a, b) => b.own - a.own);
+        const totalCount = sorted.length;
+        const items = limit > 0 ? sorted.slice(0, limit) : sorted;
+
+        const top: TopItemData[] = items.map(s => {
+            const key = s.key();
+            return {
+                key,
+                scope: s.scope,
+                module: s.module,
+                own: s.own,
+                total: s.total,
+                line: s.minLine,
+                callers: this._serializeCallers(s, new Set([key]), 3),
+            };
+        });
+        this._view!.webview.postMessage({ top, totalCount });
     }
 
     private _getHtml(webview: vscode.Webview): string {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -5,6 +5,7 @@ export const DEFAULT_PATH = "austin";
 export const DEFAULT_INTERVAL = 100;
 export const DEFAULT_MODE = AustinMode.WallTime;
 export const DEFAULT_LINE_STATS = AustinLineStats.PERCENT;
+export const DEFAULT_TOP_ROWS = 50;
 
 export class AustinRuntimeSettings {
     private static config = vscode.workspace.getConfiguration('austin');
@@ -22,6 +23,7 @@ export class AustinRuntimeSettings {
         const austinLineStats: AustinLineStats = AustinRuntimeSettings.config.get("lineStats", DEFAULT_LINE_STATS);
         const austinChildren: boolean = AustinRuntimeSettings.config.get("children", false);
         const austinGC: boolean = AustinRuntimeSettings.config.get("gc", false);
+        const austinTopRows: number = AustinRuntimeSettings.config.get("topRows", DEFAULT_TOP_ROWS);
 
         this.settings = {
             path: austinPath,
@@ -30,6 +32,7 @@ export class AustinRuntimeSettings {
             lineStats: austinLineStats,
             children: austinChildren,
             gc: austinGC,
+            topRows: austinTopRows,
         };
     }
 
@@ -85,6 +88,10 @@ export class AustinRuntimeSettings {
 
     public static setGC(gc: boolean) {
         AustinRuntimeSettings.config.update("gc", gc, vscode.ConfigurationTarget.Global);
+    }
+
+    public static getTopRows(): number {
+        return AustinRuntimeSettings.get().settings.topRows;
     }
 
 }

--- a/src/test/suite/settings.test.ts
+++ b/src/test/suite/settings.test.ts
@@ -3,7 +3,7 @@ import * as assert from 'assert';
 // You can import and use all API from the 'vscode' module
 // as well as import your extension to test it
 import * as vscode from 'vscode';
-import { AustinRuntimeSettings, DEFAULT_INTERVAL, DEFAULT_MODE, DEFAULT_PATH } from '../../settings';
+import { AustinRuntimeSettings, DEFAULT_INTERVAL, DEFAULT_MODE, DEFAULT_PATH, DEFAULT_TOP_ROWS } from '../../settings';
 
 suite('Runtime SettingsTest Suite', () => {
 	vscode.window.showInformationMessage('Start all tests.');
@@ -12,5 +12,10 @@ suite('Runtime SettingsTest Suite', () => {
 		assert.strictEqual(AustinRuntimeSettings.get().settings.path, DEFAULT_PATH);
 		assert.strictEqual(AustinRuntimeSettings.get().settings.interval, DEFAULT_INTERVAL);
 		assert.strictEqual(AustinRuntimeSettings.get().settings.mode, DEFAULT_MODE);
+		assert.strictEqual(AustinRuntimeSettings.get().settings.topRows, DEFAULT_TOP_ROWS);
+	});
+
+	test('getTopRows returns default', () => {
+		assert.strictEqual(AustinRuntimeSettings.getTopRows(), DEFAULT_TOP_ROWS);
 	});
 });

--- a/src/test/suite/top.test.ts
+++ b/src/test/suite/top.test.ts
@@ -1,0 +1,215 @@
+import * as assert from 'assert';
+import { AustinStats, FrameObject } from '../../model';
+import { TopViewProvider } from '../../providers/top';
+import '../../stringExtension';
+import '../../mapExtension';
+
+const vscodeMock = require('vscode') as {
+    workspace: { getConfiguration: () => { get: (key: string, def: unknown) => unknown; update: () => void } };
+    commands: { executeCommand: (...args: unknown[]) => Promise<unknown> };
+};
+
+function createMockWebviewView() {
+    const messages: unknown[] = [];
+    let messageHandler: (data: unknown) => void = () => { };
+
+    const view = {
+        webview: {
+            options: {} as Record<string, unknown>,
+            onDidReceiveMessage: (handler: (data: unknown) => void) => {
+                messageHandler = handler;
+            },
+            postMessage: (data: unknown) => {
+                messages.push(data);
+                return Promise.resolve(true);
+            },
+            html: '',
+            asWebviewUri: (uri: { fsPath: string }) => uri.fsPath,
+        },
+    };
+
+    return {
+        view,
+        messages,
+        sendMessage: (data: unknown) => messageHandler(data),
+    };
+}
+
+function makeStats(count: number): AustinStats {
+    const stats = new AustinStats();
+    stats.begin('test.austin');
+    for (let i = 0; i < count; i++) {
+        const frame: FrameObject = {
+            module: `/test/module${i}.py`,
+            scope: `func${i}`,
+            line: i + 1,
+        };
+        // Give each frame a unique own-time so sort order is deterministic
+        stats.update(0, '0', [frame], (count - i) * 100);
+    }
+    stats.refresh();
+    return stats;
+}
+
+function makeStatsWithCallers(count: number): AustinStats {
+    const stats = new AustinStats();
+    stats.begin('test.austin');
+    for (let i = 0; i < count; i++) {
+        const caller: FrameObject = {
+            module: `/test/caller${i}.py`,
+            scope: `caller_func${i}`,
+            line: 1,
+        };
+        const callee: FrameObject = {
+            module: `/test/module${i}.py`,
+            scope: `func${i}`,
+            line: i + 1,
+        };
+        stats.update(0, '0', [caller, callee], (count - i) * 100);
+    }
+    stats.refresh();
+    return stats;
+}
+
+function initProvider(topRowsOverride?: number) {
+    const extensionUri = { fsPath: process.cwd() };
+    const provider = new TopViewProvider(extensionUri as any);
+
+    const mock = createMockWebviewView();
+    provider.resolveWebviewView(mock.view as any, {} as any, {} as any);
+    mock.sendMessage('initialized');
+
+    // Clear the initialization messages
+    mock.messages.length = 0;
+
+    if (topRowsOverride !== undefined) {
+        vscodeMock.workspace.getConfiguration = () => ({
+            get: (key: string, def: unknown) =>
+                key === 'topRows' ? topRowsOverride : def,
+            update: () => undefined,
+        });
+    }
+
+    return { provider, mock };
+}
+
+suite('TopViewProvider — truncation', () => {
+    let savedGetConfig: typeof vscodeMock.workspace.getConfiguration;
+
+    setup(() => {
+        savedGetConfig = vscodeMock.workspace.getConfiguration;
+    });
+
+    teardown(() => {
+        vscodeMock.workspace.getConfiguration = savedGetConfig;
+    });
+
+    test('includes all items when count is below default limit', () => {
+        const { provider, mock } = initProvider();
+        const stats = makeStats(10);
+        provider.refresh(stats);
+
+        const msg = mock.messages.find((m: any) => m.top !== undefined) as any;
+        assert.ok(msg, 'should post a top message');
+        assert.strictEqual(msg.top.length, 10);
+        assert.strictEqual(msg.totalCount, 10);
+    });
+
+    test('includes all items when count equals the limit', () => {
+        const { provider, mock } = initProvider(20);
+        const stats = makeStats(20);
+        provider.refresh(stats);
+
+        const msg = mock.messages.find((m: any) => m.top !== undefined) as any;
+        assert.ok(msg);
+        assert.strictEqual(msg.top.length, 20);
+        assert.strictEqual(msg.totalCount, 20);
+    });
+
+    test('truncates items when count exceeds the limit', () => {
+        const { provider, mock } = initProvider(5);
+        const stats = makeStats(20);
+        provider.refresh(stats);
+
+        const msg = mock.messages.find((m: any) => m.top !== undefined) as any;
+        assert.ok(msg);
+        assert.strictEqual(msg.top.length, 5);
+        assert.strictEqual(msg.totalCount, 20);
+    });
+
+    test('keeps items sorted by own time descending after truncation', () => {
+        const { provider, mock } = initProvider(3);
+        const stats = makeStats(10);
+        provider.refresh(stats);
+
+        const msg = mock.messages.find((m: any) => m.top !== undefined) as any;
+        assert.ok(msg);
+        for (let i = 1; i < msg.top.length; i++) {
+            assert.ok(msg.top[i - 1].own >= msg.top[i].own,
+                `item ${i - 1} (own=${msg.top[i - 1].own}) should be >= item ${i} (own=${msg.top[i].own})`);
+        }
+    });
+
+    test('all items included when limit is 0 (unlimited)', () => {
+        const { provider, mock } = initProvider(0);
+        const stats = makeStats(200);
+        provider.refresh(stats);
+
+        const msg = mock.messages.find((m: any) => m.top !== undefined) as any;
+        assert.ok(msg);
+        assert.strictEqual(msg.top.length, 200);
+        assert.strictEqual(msg.totalCount, 200);
+    });
+
+    test('totalCount reflects total entries before truncation', () => {
+        const { provider, mock } = initProvider(2);
+        const stats = makeStats(100);
+        provider.refresh(stats);
+
+        const msg = mock.messages.find((m: any) => m.top !== undefined) as any;
+        assert.ok(msg);
+        assert.strictEqual(msg.top.length, 2);
+        assert.strictEqual(msg.totalCount, 100);
+    });
+
+    test('serialized items include caller data', () => {
+        const { provider, mock } = initProvider(3);
+        const stats = makeStatsWithCallers(5);
+        provider.refresh(stats);
+
+        const msg = mock.messages.find((m: any) => m.top !== undefined) as any;
+        assert.ok(msg);
+        assert.strictEqual(msg.top.length, 3);
+        for (const item of msg.top) {
+            assert.ok(item.callers !== undefined, 'each item should have callers');
+            assert.ok(Array.isArray(item.callers));
+        }
+    });
+});
+
+suite('TopViewProvider — openSettings message', () => {
+    let savedExecCommand: typeof vscodeMock.commands.executeCommand;
+    let executedCommands: unknown[][];
+
+    setup(() => {
+        savedExecCommand = vscodeMock.commands.executeCommand;
+        executedCommands = [];
+        vscodeMock.commands.executeCommand = (...args: unknown[]) => {
+            executedCommands.push(args);
+            return Promise.resolve(undefined);
+        };
+    });
+
+    teardown(() => {
+        vscodeMock.commands.executeCommand = savedExecCommand;
+    });
+
+    test('openSettings message opens settings filtered to austin.topRows', () => {
+        const { mock } = initProvider();
+        mock.sendMessage('openSettings');
+
+        assert.strictEqual(executedCommands.length, 1);
+        assert.strictEqual(executedCommands[0][0], 'workbench.action.openSettings');
+        assert.strictEqual(executedCommands[0][1], 'austin.topRows');
+    });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,4 +17,5 @@ export class AustinSettings {
     lineStats: AustinLineStats = AustinLineStats.PERCENT;
     children: boolean = false;
     gc: boolean = false;
+    topRows: number = 50;
 }


### PR DESCRIPTION
We cap the number of entires in the top view for faster rendering. This can be configured via the extension settings. The reason for capping entries if with large profiles, especially native ones that can have many different stacks.