### PR TITLE
fix: keep stats hidden

### DIFF
--- a/changelog/keep-stats-hidden-e37852af.fix.md
+++ b/changelog/keep-stats-hidden-e37852af.fix.md
@@ -1,0 +1,3 @@
+Fixed stats behavior to remain hidden when they are dismissed after editing the
+file they appear on. Switching tabs back won't bring them back up, unless a
+flame graph frame is clicked.

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -4,7 +4,7 @@ import { AustinProfileTaskProvider } from './providers/task';
 import { AustinRuntimeSettings } from './settings';
 import { isPythonExtensionAvailable } from './utils/pythonExtension';
 import { AustinVersionError, checkAustinVersion } from './utils/versionCheck';
-import { clearDecorations, setLinesHeat } from './view';
+import { activateDecorationsFor, clearDecorations, setLinesHeat } from './view';
 import psList = require('ps-list');
 
 
@@ -149,6 +149,7 @@ export class AustinController {
                 ));
                 const lines = this.stats.locationMap.get(module);
                 if (lines) {
+                    activateDecorationsFor(doc.uri.fsPath);
                     setLinesHeat(lines, this.stats);
                 }
             });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { clearDecorations, formatInterval, setLinesHeat } from './view';
+import { clearDecorations, deactivateAllDecorations, formatInterval, hasActiveDecorations, setLinesHeat } from './view';
 import { FlameGraphViewProvider } from './providers/flamegraph';
 import { AustinController } from './controller';
 import { AustinStats } from './model';
@@ -19,6 +19,7 @@ import { updateMcpJsonIfPresent, writeMcpJson } from './utils/mcpJson';
 export async function activate(context: vscode.ExtensionContext) {
 	vscode.workspace.onDidChangeTextDocument((_changeEvent) => {
 		clearDecorations();
+		deactivateAllDecorations();
 	});
 
 	const stats = new AustinStats();
@@ -44,8 +45,12 @@ export async function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(
 		vscode.window.onDidChangeActiveTextEditor((editor) => {
 			if (editor?.document.uri.scheme === "file") {
-				const lines = stats.locationMap.get(editor.document.uri.fsPath);
-				if (lines) { setLinesHeat(lines, stats); }
+				const path = editor.document.uri.fsPath;
+				if (hasActiveDecorations(path)) {
+					const lines = stats.locationMap.get(path);
+					if (lines) { setLinesHeat(lines, stats); }
+					else { clearDecorations(); }
+				}
 				else { clearDecorations(); }
 			}
 		})
@@ -83,8 +88,11 @@ export async function activate(context: vscode.ExtensionContext) {
 	stats.registerAfterCallback((stats) => {
 		const editor = vscode.window.activeTextEditor;
 		if (editor?.document.uri.scheme === "file") {
-			const lines = stats.locationMap.get(editor.document.uri.fsPath);
-			if (lines) { setLinesHeat(lines, stats); }
+			const path = editor.document.uri.fsPath;
+			if (hasActiveDecorations(path)) {
+				const lines = stats.locationMap.get(path);
+				if (lines) { setLinesHeat(lines, stats); }
+			}
 		}
 	});
 

--- a/src/view.ts
+++ b/src/view.ts
@@ -6,10 +6,28 @@ import { AustinLineStats } from './types';
 
 let decorators: vscode.TextEditorDecorationType[] = [];
 
+// Files for which the user has explicitly requested decorations (by clicking a
+// flamegraph frame). Tab switches and live-profile refreshes only reapply
+// decorations for files in this set; editing any file clears it, so cleared
+// decorations don't silently reappear when switching tabs.
+const activeDecorationPaths = new Set<string>();
+
 
 export function clearDecorations() {
     decorators.forEach((ld) => ld.dispose());
     decorators = [];
+}
+
+export function activateDecorationsFor(path: string) {
+    activeDecorationPaths.add(path);
+}
+
+export function deactivateAllDecorations() {
+    activeDecorationPaths.clear();
+}
+
+export function hasActiveDecorations(path: string): boolean {
+    return activeDecorationPaths.has(path);
 }
 
 


### PR DESCRIPTION
Once the stats get hidden they should not reappear unless the flame graph is clicked again.

Fixes #118.