### PR TITLE
fix: improve Cython demangling

### DIFF
--- a/changelog/improved-cython-demangling-def526e9.fix.md
+++ b/changelog/improved-cython-demangling-def526e9.fix.md
@@ -1,0 +1,1 @@
+Improved Cython demangling to handle generator body and fused-type symbols

--- a/src/test/suite/demangle.test.ts
+++ b/src/test/suite/demangle.test.ts
@@ -313,6 +313,27 @@ suite('demangle — Cython symbols', () => {
         );
     });
 
+    test('demangles __pyx_gb_ generator body', () => {
+        assert.strictEqual(
+            demangle('__pyx_gb_8bytecode_8concrete_16ConcreteBytecode_4generator'),
+            'bytecode.concrete.ConcreteBytecode.generator'
+        );
+    });
+
+    test('demangles __pyx_fuse_ specialization (wrapper)', () => {
+        assert.strictEqual(
+            demangle('__pyx_fuse_0__pyx_pw_11test_cython_13fused_func'),
+            'test_cython.fused_func'
+        );
+    });
+
+    test('demangles __pyx_fuse_ specialization (second type)', () => {
+        assert.strictEqual(
+            demangle('__pyx_fuse_1__pyx_pw_11test_cython_15fused_func'),
+            'test_cython.fused_func'
+        );
+    });
+
     test('returns non-pyx names unchanged', () => {
         assert.strictEqual(demangle('__pyx_tp_new_SomeType'), '__pyx_tp_new_SomeType');
     });

--- a/src/utils/demangle.ts
+++ b/src/utils/demangle.ts
@@ -653,9 +653,14 @@ function decodeRustEscapes(name: string): string {
 // symbols, the final segment has a numeric method-index counter that
 // must be stripped.
 
-const CYTHON_PREFIX_RE = /^__pyx_(?:pw|pf|f)_/;
+const CYTHON_PREFIX_RE = /^__pyx_(?:pw|pf|gb|f)_/;
+const CYTHON_FUSE_RE = /^__pyx_fuse_\d+/;
 
 function demangleCython(name: string): string | null {
+    // Fused-type specializations: strip the __pyx_fuse_N prefix, then fall through
+    const stripped = name.replace(CYTHON_FUSE_RE, '');
+    if (stripped !== name) { name = stripped; }
+
     const m = name.match(CYTHON_PREFIX_RE);
     if (!m) { return null; }
 


### PR DESCRIPTION
We improve Cython demangling by adding support for generator bodies and fused-type symbols.